### PR TITLE
Make sure we use the clean name for deploy Url

### DIFF
--- a/app/views/apps/show.html.erb
+++ b/app/views/apps/show.html.erb
@@ -9,7 +9,7 @@
       </tr>
       <tr>
         <th style="width: 20%">Deploy URL</th>
-        <td>dokku@<%= @app.server.ip %>:<%= @app.name %></td>
+        <td>dokku@<%= @app.server.ip %>:<%= @app.clean_name %></td>
         <td></td>
       </tr>
       <tr>


### PR DESCRIPTION
We need to use the `clean_name` otherwise we end up with spaces and other weird characters which git/dokky will refuse to work with