### PR TITLE
Make sure the deploy key is proparly formatted

### DIFF
--- a/app/models/deploy_key.rb
+++ b/app/models/deploy_key.rb
@@ -2,4 +2,8 @@ class DeployKey < ActiveRecord::Base
   belongs_to :server
 
   validates :name, :key, presence: true
+
+  def name=(value)
+    self[:name] = value.parameterize unless value.nil?
+  end
 end

--- a/test/models/deploy_key_test.rb
+++ b/test/models/deploy_key_test.rb
@@ -5,4 +5,9 @@ class DeployKeyTest < ActiveSupport::TestCase
 
   should validate_presence_of :name
   should validate_presence_of :key
+
+  test "#name= should parameterize the given value" do
+    deploy_key = DeployKey.new(name: "name with space")
+    assert_equal "name-with-space", deploy_key.name
+  end
 end


### PR DESCRIPTION
Dokku does not allow deploy keys that are not parameterized. Since we want to
make sure Dokku gets the proper value, lets parameterize the value in the setter

Fixes: #14

/cc @brambokdam