### PR TITLE
Redirect to server after creation

### DIFF
--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -24,7 +24,7 @@ class ServersController < ApplicationController
     @server = Server.new(server_params)
     if @server.save
       flash[:success] = "Your new server is added to your dashboard"
-      redirect_to root_path
+      redirect_to server_path(@server)
     else
       render :new
     end

--- a/test/controllers/servers_controller_test.rb
+++ b/test/controllers/servers_controller_test.rb
@@ -10,4 +10,11 @@ class ServersControllerTest < ActionController::TestCase
     get :new
     assert_response :success
   end
+
+  test "POST create should create a new server and then redirect to that server" do
+    assert_difference "Server.count" do
+      post :create, server: { name: "test-server", ip: "127.0.0.1" }
+    end
+    assert_response :redirect
+  end
 end

--- a/test/integration/new_server_test.rb
+++ b/test/integration/new_server_test.rb
@@ -13,6 +13,6 @@ class NewServerTest < ActionDispatch::IntegrationTest
       click_button "Create server"
     end
 
-    assert_equal root_path, current_path
+    assert_equal server_path(Server.last), current_path
   end
 end


### PR DESCRIPTION
We want to give the user a smooth experience, this can be improved by
redirecting to the server object after it has been created. That way the user
gets a better feeling of the Server creation flow.

Fixes #13

/cc @brambokdam