### PR TITLE
Show a first launch page when there are no users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,15 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :require_login
+  before_action :redirect_if_first_user
 
   protected
 
   def not_authenticated
     redirect_to login_path
+  end
+
+  def redirect_if_first_user
+    redirect_to welcome_path unless User.any?
   end
 end

--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -1,0 +1,32 @@
+class OnboardingController < ApplicationController
+  skip_before_action :require_login
+  skip_before_action :redirect_if_first_user
+
+  before_action :redirect_unless_first_user
+
+  layout "login"
+
+  def index
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      auto_login(@user)
+      redirect_to root_path
+    else
+      render :index
+    end
+  end
+
+  private
+
+  def redirect_unless_first_user
+    redirect_to root_path if User.any?
+  end
+
+  def user_params
+    params.require(:user).permit(:email, :password)
+  end
+end

--- a/app/views/onboarding/index.html.erb
+++ b/app/views/onboarding/index.html.erb
@@ -1,0 +1,18 @@
+<div class="col-md-6 col-md-offset-3">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title">Welcome to Intercity</h3>
+    </div>
+    <%= bootstrap_form_for @user, url: welcome_path do |f| %>
+      <div class="panel-body">
+        <p>Since this is the first time you start the app,
+        we ask you to create the first user account. After you have created your account, this page will be gone</p>
+          <%= f.text_field :email %>
+          <%= f.password_field :password %>
+      </div>
+      <div class="panel-footer">
+        <%= f.submit "Create first account", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,12 @@ Rails.application.routes.draw do
 
   root to: "servers#index"
 
+  get "welcome" => "onboarding#index", as: "welcome"
+  post "welcome" => "onboarding#create"
   get "login" => "sessions#new", as: "login"
   post "login" => "sessions#create"
   delete "logout" => "sessions#destroy", as: "logout"
+
 
   resources :servers, only: [:new, :create, :show, :destroy] do
     get :test, on: :member

--- a/test/controllers/onboarding_controller_test.rb
+++ b/test/controllers/onboarding_controller_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class OnboardingControllerTest < ActionController::TestCase
+  test "GET index should be successfull when there are no other users" do
+    User.destroy_all
+
+    get :index
+
+    assert_response :success
+  end
+
+  test "GET index should redirect to root path when there is a user in the system" do
+    get :index
+
+    assert_response :redirect
+  end
+
+  test "POST create should create a new user if there are no other users" do
+    User.destroy_all
+
+    assert_difference "User.count" do
+      post :create, user: { email: "user@example.com", password: "secret" }
+    end
+
+    assert_response :redirect
+  end
+end

--- a/test/integration/first_launch_test.rb
+++ b/test/integration/first_launch_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class FirstLaunchTest < ActionDispatch::IntegrationTest
+  test "When there are no users in the system, you should see the onboarding page" do
+    User.destroy_all
+
+    visit root_path
+
+    fill_in "user[email]", with: "user@example.com"
+    fill_in "user[password]", with: "secret"
+    click_button "Create first account"
+
+    assert_equal root_path, current_path
+  end
+end


### PR DESCRIPTION
We don't want administrators messing around on the console to add their first
user, so in order to avoid that I added a welcome page that is shown when there
are no users in the system.

Fixes #20

/cc @michiels / @brambokdam 