### PR TITLE
Seed plugins via a rake task

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,21 +1,3 @@
 User.create!(email: "user@example.com", password: "12345678")
 
-Service.create!(name: "Redis", active: true,
-                commands: { install: "sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis",
-                            create: "dokku redis:create %app_name%_redis",
-                            link: "dokku redis:link %app_name%_redis %app_name%" })
-
-Service.create!(name: "Postgres", active: true,
-                commands: { install: "sudo dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres",
-                            create: "dokku postgres:create %app_name%_postgres",
-                            link: "dokku postgres:link %app_name%_postgres %app_name%" })
-
-Service.create!(name: "Mysql", active: true,
-                commands: { install: "dokku plugin:install https://github.com/dokku/dokku-mysql.git mysql",
-                            create: "dokku mysql:create %app_name%_mysql",
-                            link: "dokku mysql:link %app_name%_mysql %app_name%" })
-
-Service.create!(name: "Elasticsearch", active: true,
-                commands: { install: "dokku plugin:install https://github.com/dokku/dokku-elasticsearch.git elasticsearch",
-                            create: "dokku elasticsearch:create %app_name%_elasticsearch",
-                            link: "dokku elasticsearch:link %app_name%_elasticsearch %app_name%" })
+Rake::Task["intercity:seed_plugins"].invoke

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -1,0 +1,28 @@
+namespace :intercity do
+  desc "Seed plugins"
+  task seed_plugins: :environment do
+    plugins = [
+      { name: "Redis", active: true,
+        commands: { install: "sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis",
+                    create: "dokku redis:create %app_name%_redis",
+                    link: "dokku redis:link %app_name%_redis %app_name%" }},
+      { name: "Postgres", active: true,
+        commands: { install: "sudo dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres",
+                    create: "dokku postgres:create %app_name%_postgres",
+                    link: "dokku postgres:link %app_name%_postgres %app_name%" }},
+      { name: "Mysql", active: true,
+        commands: { install: "dokku plugin:install https://github.com/dokku/dokku-mysql.git mysql",
+                    create: "dokku mysql:create %app_name%_mysql",
+                    link: "dokku mysql:link %app_name%_mysql %app_name%" }},
+      { name: "Elasticsearch", active: true,
+        commands: { install: "dokku plugin:install https://github.com/dokku/dokku-elasticsearch.git elasticsearch",
+                    create: "dokku elasticsearch:create %app_name%_elasticsearch",
+                    link: "dokku elasticsearch:link %app_name%_elasticsearch %app_name%" }}
+    ]
+
+    plugins.each do |plugin_data|
+      plugin = Service.find_or_initialize_by(name: plugin_data[:name])
+      plugin.update(plugin_data)
+    end
+  end
+end


### PR DESCRIPTION
When someone installs Intercity, we want to give them access to plugins. Since
we use a database to store them in for now, we also need to seed that DB.

This Rake task will be called upon a intercity-docker bootstrap call (So
everytime someone installs or updates their IC instance), and so it will always
be up to date.

To keep it in sync with dev, and make sure it works correctly, we also use this
task for dev seeding

/cc @brambokdam 