### PR TITLE
Add feedback to the installation process

### DIFF
--- a/app/views/servers/check_installation.js.erb
+++ b/app/views/servers/check_installation.js.erb
@@ -2,20 +2,9 @@
   $("[data-server-status~=checking]").addClass("hidden");
   $("[data-server-status~=connected]").removeClass("hidden");
 <% else %>
-  <% if @server.install_step == 1 %>
-    $(".step1").addClass("info").find("td:first-child").html("<%= j icon "circle-o-notch fa-spin" %>");
-  <% elsif @server.install_step == 2 %>
-    $(".step1").removeClass("info").addClass("success").find("td:first-child").html("<%= j icon "check-square-o" %>");
-    $(".step2").addClass("info").find("td:first-child").html("<%= j icon "circle-o-notch fa-spin" %>");
-  <% elsif @server.install_step == 3 %>
-    $(".step1").removeClass("info").addClass("success").find("td:first-child").html("<%= j icon "check-square-o" %>");
-    $(".step2").removeClass("info").addClass("success").find("td:first-child").html("<%= j icon "check-square-o" %>");
-    $(".step3").addClass("info").find("td:first-child").html("<%= j icon "circle-o-notch fa-spin" %>");
-  <% elsif @server.install_step == 4 %>
-    $(".step1").removeClass("info").addClass("success").find("td:first-child").html("<%= j icon "check-square-o" %>");
-    $(".step2").removeClass("info").addClass("success").find("td:first-child").html("<%= j icon "check-square-o" %>");
-    $(".step3").removeClass("info").addClass("success").find("td:first-child").html("<%= j icon "check-square-o" %>");
-    $(".step4").addClass("info").find("td:first-child").html("<%= j icon "circle-o-notch fa-spin" %>");
+  <% for n in 1...@server.install_step %>
+    $(".step<%= n %>").removeClass("info").addClass("success").find("td:first-child").html("<%= j icon "check-square-o" %>");
   <% end %>
+  $(".step<%= @server.install_step %>").addClass("info").find("td:first-child").html("<%= j icon "circle-o-notch fa-spin" %>");
   new ServerPoller("<%= check_installation_server_path(@server) %>").poll();
 <% end %>

--- a/app/views/servers/check_installation.js.erb
+++ b/app/views/servers/check_installation.js.erb
@@ -2,5 +2,20 @@
   $("[data-server-status~=checking]").addClass("hidden");
   $("[data-server-status~=connected]").removeClass("hidden");
 <% else %>
+  <% if @server.install_step == 1 %>
+    $(".step1").addClass("info").find("td:first-child").html("<%= j icon "circle-o-notch fa-spin" %>");
+  <% elsif @server.install_step == 2 %>
+    $(".step1").removeClass("info").addClass("success").find("td:first-child").html("<%= j icon "check-square-o" %>");
+    $(".step2").addClass("info").find("td:first-child").html("<%= j icon "circle-o-notch fa-spin" %>");
+  <% elsif @server.install_step == 3 %>
+    $(".step1").removeClass("info").addClass("success").find("td:first-child").html("<%= j icon "check-square-o" %>");
+    $(".step2").removeClass("info").addClass("success").find("td:first-child").html("<%= j icon "check-square-o" %>");
+    $(".step3").addClass("info").find("td:first-child").html("<%= j icon "circle-o-notch fa-spin" %>");
+  <% elsif @server.install_step == 4 %>
+    $(".step1").removeClass("info").addClass("success").find("td:first-child").html("<%= j icon "check-square-o" %>");
+    $(".step2").removeClass("info").addClass("success").find("td:first-child").html("<%= j icon "check-square-o" %>");
+    $(".step3").removeClass("info").addClass("success").find("td:first-child").html("<%= j icon "check-square-o" %>");
+    $(".step4").addClass("info").find("td:first-child").html("<%= j icon "circle-o-notch fa-spin" %>");
+  <% end %>
   new ServerPoller("<%= check_installation_server_path(@server) %>").poll();
 <% end %>

--- a/app/views/servers/show/add_ssh.html.erb
+++ b/app/views/servers/show/add_ssh.html.erb
@@ -2,7 +2,7 @@
 <p>You need to add the following public SSH key to the "root" user of the server</p>
 <pre><%= @ssh_key %></pre>
 <div class="well text-center <%= "hidden" if @server.connected? %>" data-server-status="checking">
-  <p><i class="fa fa-circle-o-notch fa-spin"></i> Testing for connection</p>
+  <p><i class="fa fa-circle-o-notch fa-spin"></i> Checking for the SSH key</p>
   <p class="hint hidden"></p>
 </div>
 <div class="well text-center <%= "hidden" unless @server.connected? %>" data-server-status="connected">

--- a/app/views/servers/show/installing.html.erb
+++ b/app/views/servers/show/installing.html.erb
@@ -1,7 +1,28 @@
 <h1>Setup for <%= @server.name %></h1>
 <p>We are installing your server. This can take around 10 minutes</p>
-<div class="well text-center <%= "hidden" if @server.up? %>" data-server-status="checking">
-  <p><i class="fa fa-circle-o-notch fa-spin"></i> Testing for connection</p>
+<div class="well <%= "hidden" if @server.up? %>" data-server-status="checking">
+  <div class="row">
+    <div class="col-md-4 col-md-offset-4">
+      <table class="table">
+        <tr class="step1 info">
+          <td class="actions"><%= icon "circle-o-notch fa-spin" %></td>
+          <td class="text-center">Updating packages</td>
+        </tr>
+        <tr class="step2">
+          <td><%= icon "square-o" %></td>
+          <td class="text-center">Installing Docker</td>
+        </tr>
+        <tr class="step3">
+          <td><%= icon "square-o" %></td>
+          <td class="text-center">Installing Dokku</td>
+        </tr>
+        <tr class="step4">
+          <td><%= icon "square-o" %></td>
+          <td class="text-center">Importing base image</td>
+        </tr>
+      </table>
+    </div>
+  </div>
 </div>
 <div class="well text-center <%= "hidden" unless @server.up? %>" data-server-status="connected">
   <p>The server is installed and ready to go!</p>

--- a/db/migrate/20160112144254_add_install_step_to_server.rb
+++ b/db/migrate/20160112144254_add_install_step_to_server.rb
@@ -1,0 +1,5 @@
+class AddInstallStepToServer < ActiveRecord::Migration
+  def change
+    add_column :servers, :install_step, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160106115246) do
+ActiveRecord::Schema.define(version: 20160112144254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 20160106115246) do
     t.boolean  "connected",       default: false
     t.integer  "status",          default: 0
     t.string   "dokku_version"
+    t.integer  "install_step",    default: 1
   end
 
   create_table "services", force: :cascade do |t|


### PR DESCRIPTION
Since the installation can take a little while, it is good to show the user some
feedback on the progress. I did split up the installation in 4 steps:

* Updating packages
* Installing Docker
* Installing Dokku
* Importing base image

We check the output from the server, and determine based on that what the status
should be on the installation page.