### PR TITLE
Remove the email address from the activation mail.

### DIFF
--- a/app/views/user_mailer/activation.html.erb
+++ b/app/views/user_mailer/activation.html.erb
@@ -1,3 +1,3 @@
-<h1>Welcome to Intercity, <%= @user.email %></h1>
+<h1>Welcome to Intercity</h1>
 
 <p>An account for Intercity is created for you. To complete your user account, just follow this <%= link_to "link", @url %>.</p>


### PR DESCRIPTION
The activation email that you get when you are invited to Intercity looks a bit odd. It suggests that your
email address is your name. Now the email address is removed from the title and the title is just "Welcome to intercity".

Fixes: #54