### PR TITLE
Move sidekiq config to this repository

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec rails s
-sidekiq: bundle exec sidekiq -q mailers -q default
+sidekiq: bundle exec sidekiq

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,9 @@
+---
+:concurrency: 5
+:pidfile: tmp/sidekiq.pid
+:logfile: log/sidekiq.log
+production:
+  :concurrency: 20
+:queues:
+  - default
+  - mailers


### PR DESCRIPTION
By moving the config here, we can easily add new queues without having to update
the `intercity/intercity-docker` repo.

Fixes: #46