### PR TITLE
Add automated healthchecks

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,6 +7,7 @@
 //= require nprogress-turbolinks
 //= require server_test
 //= require server_poller
+//= require health_check
 //= require turbolinks
 
 $(function() {

--- a/app/assets/javascripts/health_check.coffee
+++ b/app/assets/javascripts/health_check.coffee
@@ -1,0 +1,5 @@
+$ ->
+  $("body").on "click", "[data-behaviour~=perform-health-check]", (e) ->
+    $(this).addClass("hidden")
+    $(this).next("[data-behaviour~=performing-health-check]").removeClass("hidden")
+

--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -1,0 +1,7 @@
+class HealthChecksController < ApplicationController
+  def create
+    @server = Server.find(params[:server_id])
+
+    HealthCheckJob.perform_now(@server)
+  end
+end

--- a/app/jobs/health_check_job.rb
+++ b/app/jobs/health_check_job.rb
@@ -1,0 +1,19 @@
+class HealthCheckJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(server)
+    return unless server.up? || server.down?
+    version = SshExecution.new(server).execute(command: "dokku version")
+    server.update(dokku_version: format_version(version), status: "up")
+
+  rescue Net::SSH::ConnectionTimeout, Net::SSH::AuthenticationFailed, Errno::EHOSTUNREACH,
+         Errno::ECONNREFUSED, Errno::EHOSTDOWN
+    server.update(status: "down")
+  end
+
+  private
+
+  def format_version(version)
+    "v#{version.strip}"
+  end
+end

--- a/app/jobs/schedule_health_checks_job.rb
+++ b/app/jobs/schedule_health_checks_job.rb
@@ -1,0 +1,9 @@
+class ScheduleHealthChecksJob < ActiveJob::Base
+  queue_as :health_cheacks
+
+  def perform
+    Server.all.each do |server|
+      HealthCheckJob.perform_later(server)
+    end
+  end
+end

--- a/app/views/health_checks/create.js.erb
+++ b/app/views/health_checks/create.js.erb
@@ -1,0 +1,7 @@
+<% if @server.down? %>
+  $("[data-behaviour~=perform-health-check]").removeClass("hidden");
+  $("[data-behaviour~=performing-health-check]").addClass("hidden");
+<% else %>
+  $("[data-server-status~=down]").addClass("hidden");
+  $("[data-server-status~=up]").removeClass("hidden");
+<% end %>

--- a/app/views/servers/show/down.html.erb
+++ b/app/views/servers/show/down.html.erb
@@ -1,0 +1,20 @@
+<div class="row">
+  <div class="col-md-6 col-md-offset-3 text-center" data-server-status="down">
+    <h1>Server <%= @server.name %> seems to be down</h1>
+    <p>We could not connect to your server during the last healthcheck.</p>
+    <p>Please check if the server is still online and accepting connections</p>
+    <p>We keep checking this server every 30 minutes to see if it comes online.</p>
+    <div class="well">
+      <%= link_to "Force healthcheck", server_health_check_path(@server), method: :post, remote: true,
+        class: "btn btn-default", data: { behaviour: "perform-health-check" } %>
+      <p data-behaviour="performing-health-check" class="hidden"><%= icon "circle-o-notch fa-spin" %> Performing healthcheck</p>
+    </div>
+  </div>
+  <div class="col-md-6 col-md-offset-3 text-center hidden" data-server-status="up">
+    <h1>Server <%= @server.name %> is back online!</h1>
+    <div class="well">
+      <%= link_to "Go to server", server_path(@server), class: "btn btn-default" %>
+    </div>
+  </div>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     get :test_ssh, on: :member
     get :check_installation, on: :member
     post :start_installation, on: :member
+    resource :health_check, only: [:create]
     resources :apps, only: [:index, :new, :create, :destroy, :show] do
       resources :services, controller: "app_services", only: :index do
         post :create, on: :member

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -3,3 +3,8 @@ schedule_automated_backups:
   class: "ScheduleAutomatedBackupsJob"
   queue: default
   active_job: true
+schedule_health_checks:
+  cron: "0,30 * * * *"
+  class: "ScheduleHealthChecks"
+  queue: health_checks
+  active_job: true

--- a/test/controllers/health_checks_controller_test.rb
+++ b/test/controllers/health_checks_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class HealthChecksControllerTest < ActionController::TestCase
+  test "should get create" do
+    login_user users(:john)
+    server = servers(:example)
+
+    HealthCheckJob.any_instance.expects(:perform_now)
+
+    xhr :post, :create, server_id: server
+
+    assert_response :success
+  end
+end

--- a/test/jobs/health_check_job_test.rb
+++ b/test/jobs/health_check_job_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class HealthCheckJobTest < ActiveJob::TestCase
+  test "#perform should call out to SshExecution to test if server is available" do
+    server = servers(:example)
+
+    SshExecution.any_instance.expects(:execute).returns("0.4.6")
+    HealthCheckJob.perform_now(server)
+  end
+
+  test "#perform updates the dokku_version of the server if it is out of sync" do
+    server = servers(:example).tap { |s| s.update(dokku_version: "0.4.6") }
+
+    SshExecution.any_instance.expects(:execute).returns("0.4.8")
+    HealthCheckJob.perform_now(server)
+
+    assert_equal "v0.4.8", server.reload.dokku_version
+  end
+
+  test "#perform should put the server in down state if we can't connect" do
+    server = servers(:example).tap { |s| s.update(status: "up") }
+
+    SshExecution.any_instance.expects(:execute).raises(Errno::EHOSTDOWN)
+    HealthCheckJob.perform_now(server)
+
+    assert_equal "down", server.reload.status
+  end
+
+  test "#perform should not run the check when status is other then up or down" do
+    server = servers(:example).tap { |s| s.update(status: "installing") }
+
+    SshExecution.any_instance.expects(:execute).never
+    HealthCheckJob.perform_now(server)
+  end
+end

--- a/test/jobs/schedule_health_checks_job_test.rb
+++ b/test/jobs/schedule_health_checks_job_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class ScheduleHealthChecksJobTest < ActiveJob::TestCase
+  test "#perform should schedule a healthcheck for every available server" do
+    available_servers = 2
+
+    HealthCheckJob.expects(:perform_later).times(available_servers)
+    ScheduleHealthChecksJob.perform_now
+  end
+end


### PR DESCRIPTION
The healthchecks should run every 30 minutes to check if the server is still
accessible.

If the server is accessible, we also take the time to sync the Dokku version,
since it might be out of sync if the user manually updated their Dokku instance.

When the server is down, we want to give the user the possibility to force a new
healthcheck, you can do so from the Server is Down page.

Fixes: #28

**Server overview**
![image](https://cloud.githubusercontent.com/assets/1362793/12323139/454a76da-bab9-11e5-871f-b64cb611f686.png)

**Server is down page**
![image](https://cloud.githubusercontent.com/assets/1362793/12323151/50f18168-bab9-11e5-9a3c-d7a8bb082e46.png)

/cc @brambokdam 

