### PR TITLE
Add password length validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ActiveRecord::Base
   validates :email, presence: true
   validates :email, uniqueness: true, email_format: true, if: -> { email.present? }
   validates :password, presence: true, unless: -> { skip_password_validation }
+  validates :password, length: { minimum: 8 }, if: -> { password.present? }
 
   def email=(value)
     self[:email] = value.downcase unless value.nil?

--- a/test/controllers/onboarding_controller_test.rb
+++ b/test/controllers/onboarding_controller_test.rb
@@ -19,7 +19,7 @@ class OnboardingControllerTest < ActionController::TestCase
     User.destroy_all
 
     assert_difference "User.count" do
-      post :create, user: { email: "user@example.com", password: "secret" }
+      post :create, user: { email: "user@example.com", password: "secret_password" }
     end
 
     assert_response :redirect

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -31,7 +31,7 @@ class UsersControllerTest < ActionController::TestCase
 
   test "POST confirm should be successfull" do
     user = users(:jane)
-    patch :confirm, token: user.activation_token, user: { password: "1234" }
+    patch :confirm, token: user.activation_token, user: { password: "secret_password" }
 
     assert_response :redirect
   end

--- a/test/integration/first_launch_test.rb
+++ b/test/integration/first_launch_test.rb
@@ -7,7 +7,7 @@ class FirstLaunchTest < ActionDispatch::IntegrationTest
     visit root_path
 
     fill_in "user[email]", with: "user@example.com"
-    fill_in "user[password]", with: "secret"
+    fill_in "user[password]", with: "secret_password"
     click_button "Create first account"
 
     assert_equal root_path, current_path

--- a/test/integration/user_activation_test.rb
+++ b/test/integration/user_activation_test.rb
@@ -5,7 +5,7 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     user = users(:jane)
     visit activate_users_path(token: user.activation_token)
 
-    fill_in "user[password]", with: "secret"
+    fill_in "user[password]", with: "secret_password"
     click_button "Finish your account"
 
     assert_equal login_path, current_path

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -7,6 +7,7 @@ class UserTest < ActiveSupport::TestCase
   should allow_value("john@example.nl").for(:email)
   should allow_value("john+doe@example.com").for(:email)
   should allow_value("john@example.city").for(:email)
+  should validate_length_of(:password).is_at_least(8)
 
   test "It lowercases the email in the setter" do
     user = User.new(email: "John@example.com")


### PR DESCRIPTION
You could now activate your account with just one char. With this the minimum length of a password is 8 chars.

Fixes: #53