### PR TITLE
Update servers when newer version is available.

### DIFF
--- a/app/controllers/app_services_controller.rb
+++ b/app/controllers/app_services_controller.rb
@@ -1,6 +1,6 @@
-class AppServicesController < ApplicationController
+class AppServicesController < ServerBaseController
   def index
-    @app = Server.find(params[:server_id]).apps.find(params[:app_id])
+    @app = server.apps.find(params[:app_id])
   end
 
   def create

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -1,4 +1,4 @@
-class AppsController < ApplicationController
+class AppsController < ServerBaseController
   def index
     @server = Server.includes(:apps).find(params[:server_id])
   end
@@ -30,10 +30,6 @@ class AppsController < ApplicationController
   end
 
   private
-
-  def server
-    @server ||= Server.find(params[:server_id])
-  end
 
   def app_params
     params.require(:app).permit(:name).tap do |p|

--- a/app/controllers/backups_controller.rb
+++ b/app/controllers/backups_controller.rb
@@ -1,4 +1,4 @@
-class BackupsController < ApplicationController
+class BackupsController < ServerBaseController
   def index
     @app = App.find_by!(id: params[:app_id], server: params[:server_id])
     @backups = @app.backups.order(created_at: :desc)

--- a/app/controllers/deploy_keys_controller.rb
+++ b/app/controllers/deploy_keys_controller.rb
@@ -1,4 +1,4 @@
-class DeployKeysController < ApplicationController
+class DeployKeysController < ServerBaseController
   def index
     @server = Server.find(params[:server_id])
     @deploy_keys = @server.deploy_keys

--- a/app/controllers/domains_controller.rb
+++ b/app/controllers/domains_controller.rb
@@ -1,4 +1,4 @@
-class DomainsController < ApplicationController
+class DomainsController < ServerBaseController
   def index
     @app = App.find_by!(id: params[:app_id], server: params[:server_id])
     @domain = Domain.new

--- a/app/controllers/env_vars_controller.rb
+++ b/app/controllers/env_vars_controller.rb
@@ -1,4 +1,4 @@
-class EnvVarsController < ApplicationController
+class EnvVarsController < ServerBaseController
   def index
     @app = App.find_by!(id: params[:app_id], server: params[:server_id])
     @env_var = EnvVar.new

--- a/app/controllers/server_base_controller.rb
+++ b/app/controllers/server_base_controller.rb
@@ -1,0 +1,13 @@
+class ServerBaseController < ApplicationController
+  before_action :redirect_if_updating
+
+  protected
+
+  def server
+    @server ||= Server.find(params[:server_id])
+  end
+
+  def redirect_if_updating
+    redirect_to updating_server_path(server) if server.updating?
+  end
+end

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -61,6 +61,28 @@ class ServersController < ApplicationController
     redirect_to server_path(@server)
   end
 
+  def start_update
+    @server = Server.find(params[:id])
+    if VersionParser.parse(@server.dokku_version) < VersionParser.parse("v0.4.11")
+      redirect_to manual_update_server_path(@server)
+    else
+      unless @server.updating?
+        UpdateServerJob.perform_later(@server)
+        @server.update(updating: true)
+      end
+
+      redirect_to updating_server_path(@server)
+    end
+  end
+
+  def updating
+    @server = Server.find(params[:id])
+  end
+
+  def manual_update
+    @server = Server.find(params[:id])
+  end
+
   def destroy
     @server = Server.find(params[:id])
     @server.destroy

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,4 +1,4 @@
-class ServicesController < ApplicationController
+class ServicesController < ServerBaseController
   def index
     @server = Server.find(params[:server_id])
     @available_services = Service.where(active: true).order(name: :asc)

--- a/app/jobs/update_server_job.rb
+++ b/app/jobs/update_server_job.rb
@@ -1,0 +1,30 @@
+class UpdateServerJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(server)
+    SshExecution.new(server).execute_with_block do |ssh|
+      ssh.open_channel do |channel|
+        channel.exec update_command do |exec_channel, success|
+          unless success
+            logger.error "Could not update server"
+            abort "could not update server"
+          end
+          exec_channel.on_data do |_, data|
+            logger.info data
+          end
+        end
+      end
+    end
+    SshExecution.new(server).execute(command: "dokku ps:rebuildall")
+    server.update(dokku_version: server.latest_dokku_version, updating: false)
+  end
+
+  private
+
+  def update_command
+    "sudo echo 'dokku dokku/web_config boolean false' | debconf-set-selections && " \
+      "sudo echo 'dokku dokku/vhost_enable boolean false' | debconf-set-selections && " \
+      "sudo echo 'dokku dokku/skip_key_file boolean true' | debconf-set-selections && " \
+      "sudo apt-get install -qq -y dokku"
+  end
+end

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -24,6 +24,14 @@ class Server < ActiveRecord::Base
     end
   end
 
+  def up_to_date?
+    VersionParser.parse(dokku_version) == VersionParser.parse(latest_dokku_version)
+  end
+
+  def latest_dokku_version
+    "v0.4.11".freeze
+  end
+
   private
 
   def create_rsa_key

--- a/app/views/servers/_heading.html.erb
+++ b/app/views/servers/_heading.html.erb
@@ -7,4 +7,5 @@
     <li class="<%= "active" if tab == "deploy_keys" %>"><%= link_to "Deploy keys", server_deploy_keys_path(server) %></li>
   </ul>
 </div>
+<%= render("servers/outdated", server: server) unless server.up_to_date? %>
 <%= render "flashes" -%>

--- a/app/views/servers/_outdated.html.erb
+++ b/app/views/servers/_outdated.html.erb
@@ -1,0 +1,12 @@
+<div class="alert alert-dismissible alert-warning">
+  <h4>Server out of date!</h4>
+  <div class="row">
+    <div class="col-md-10">
+      <p>The Dokku version installed on your server is not up to date. We highly recomment you update as soon as possible.
+        Keep in mind that updating does cause a short downtime.</p>
+    </div>
+    <div class="col-md-2">
+      <%= link_to "Update", start_update_server_path(server), method: :post, class: "pull-right btn-sm btn btn-default" %>
+    </div>
+  </div>
+</div>

--- a/app/views/servers/manual_update.html.erb
+++ b/app/views/servers/manual_update.html.erb
@@ -1,0 +1,13 @@
+<div class="text-center">
+    <h1>Can't automaticly update</h1>
+    <p>We can automaticly update your Dokku instance as of version <b>v0.4.11</b>, 
+    however you run version <b><%= @server.dokku_version %></b>.</p>
+    <p>To update your server, you need to manually SSH into the server, and run the following command:</p>
+    <p>
+      <pre>
+sudo echo 'dokku dokku/web_config boolean false' | debconf-set-selections && sudo echo 'dokku dokku/vhost_enable boolean false' | debconf-set-selections && sudo echo 'dokku dokku/skip_key_file boolean true' | debconf-set-selections && sudo apt-get install -qq -y dokku
+      </pre>
+    </p>
+    <p>After you updated the server, it can take up to 30 minutes for Intercity to pick
+      up the updated version.</p>
+</div>

--- a/app/views/servers/updating.html.erb
+++ b/app/views/servers/updating.html.erb
@@ -1,0 +1,1 @@
+<h1>Server is updating</h1>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,7 @@ module IntercityNext
 
     config.generators.assets = false
     config.generators.helper = false
+
+    config.autoload_paths << Rails.root.join('lib')
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,10 @@ Rails.application.routes.draw do
   resources :servers, only: [:new, :create, :show, :destroy] do
     get :test_ssh, on: :member
     get :check_installation, on: :member
+    get :updating, on: :member
+    get :manual_update, on: :member
     post :start_installation, on: :member
+    post :start_update, on: :member
     resource :health_check, only: [:create]
     resources :apps, only: [:index, :new, :create, :destroy, :show] do
       resources :services, controller: "app_services", only: :index do

--- a/db/migrate/20160108103319_add_updating_to_server.rb
+++ b/db/migrate/20160108103319_add_updating_to_server.rb
@@ -1,0 +1,5 @@
+class AddUpdatingToServer < ActiveRecord::Migration
+  def change
+    add_column :servers, :updating, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 20160112144254) do
     t.integer  "status",          default: 0
     t.string   "dokku_version"
     t.integer  "install_step",    default: 1
+    t.boolean  "updating",        default: false
   end
 
   create_table "services", force: :cascade do |t|

--- a/lib/version_parser.rb
+++ b/lib/version_parser.rb
@@ -1,0 +1,41 @@
+class VersionParser
+  include Comparable
+
+  attr_reader :major, :minor, :patch
+
+  def self.parse(version)
+    parsed = version.match(/(\d+).(\d+).(\d+)/)
+    VersionParser.new(parsed[1].to_i, parsed[2].to_i, parsed[3].to_i)
+  end
+
+  def initialize(major, minor, patch)
+    @major = major
+    @minor = minor
+    @patch = patch
+  end
+
+  def <=>(other) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    return unless other.is_a? VersionParser
+    return unless valid? && other.valid?
+
+    if other.major < @major
+      1
+    elsif @major < other.major
+      -1
+    elsif other.minor < @minor
+      1
+    elsif @minor < other.minor
+      -1
+    elsif other.patch < @patch
+      1
+    elsif @patch < other.patch
+      -1
+    else
+      0
+    end
+  end
+
+  def valid?
+    @major >= 0 && @minor >= 0 && @patch >= 0 && @major + @minor + @patch > 0
+  end
+end

--- a/test/controllers/app_services_controller_test.rb
+++ b/test/controllers/app_services_controller_test.rb
@@ -11,4 +11,13 @@ class AppServicesControllerTest < ActionController::TestCase
 
     assert_response :success
   end
+
+  test "Redirects to ServerUpdatingPath if server is busy updating" do
+    server = servers(:example).tap { |s| s.update(updating: true) }
+    app = apps(:example)
+
+    get :index, server_id: server, app_id: app
+
+    assert_response :redirect
+  end
 end

--- a/test/controllers/apps_controller_test.rb
+++ b/test/controllers/apps_controller_test.rb
@@ -21,4 +21,12 @@ class AppsControllerTest < ActionController::TestCase
 
     assert_response :success
   end
+
+  test "Redirects to ServerUpdatingPath if server is busy updating" do
+    server = servers(:example).tap { |s| s.update(updating: true) }
+
+    get :index, server_id: server
+
+    assert_response :redirect
+  end
 end

--- a/test/fixtures/servers.yml
+++ b/test/fixtures/servers.yml
@@ -5,6 +5,7 @@ example:
   rsa_key_private: "<%= File.read("test/support/private_key.pem") %>"
   connected: true
   status: 30
+  dokku_version: "v0.4.6"
 
 
 local:
@@ -12,3 +13,4 @@ local:
   ip: "127.0.0.1"
   rsa_key_public: "<%= File.read("test/support/public_key.pem") %>"
   rsa_key_private: "<%= File.read("test/support/private_key.pem") %>"
+  dokku_version: "v0.4.6"

--- a/test/lib/version_parser_test.rb
+++ b/test/lib/version_parser_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class VersionParserTest < ActiveSupport::TestCase
+  setup do
+    @v0_0_1 = VersionParser.new(0, 0, 1)
+    @v0_1_0 = VersionParser.new(0, 1, 0)
+    @v1_0_0 = VersionParser.new(1, 0, 0)
+    @v1_0_1 = VersionParser.new(1, 0, 1)
+    @v1_1_0 = VersionParser.new(1, 1, 0)
+    @v2_0_0 = VersionParser.new(2, 0, 0)
+  end
+
+  test ".parse should return a VersionParser object" do
+    version = VersionParser.parse("v0.1.2")
+    assert_equal [0, 1, 2], [version.major, version.minor, version.patch]
+
+    version = VersionParser.parse("v2.3.4")
+    assert_equal [2, 3, 4], [version.major, version.minor, version.patch]
+  end
+
+  test "> should properly compare" do
+    assert @v2_0_0 > @v1_1_0
+    assert @v1_1_0 > @v1_0_1
+    assert @v1_0_0 > @v0_1_0
+    assert @v0_1_0 > @v0_0_1
+    refute @v0_1_0 > @v1_0_0
+  end
+
+  test '>= should properly compare' do
+    assert @v2_0_0 >= VersionParser.new(2, 0, 0)
+    assert @v2_0_0 >= @v1_1_0
+  end
+end

--- a/test/models/server_test.rb
+++ b/test/models/server_test.rb
@@ -42,4 +42,14 @@ class ServerTest < ActiveSupport::TestCase
     ActiveService.find_by(server: server, service: redis).update(status: "installed")
     assert_equal "installed", server.service_status(redis)
   end
+
+  test "#up_to_date? checks if the server is up to date with current dokku version" do
+    outdated = Server.new(dokku_version: "v0.4.8")
+    outdated.stubs(:latest_dokku_version).returns("v0.4.10")
+    refute outdated.up_to_date?, "Server should be marked as not up to date"
+
+    up_to_date = Server.new(dokku_version: "v0.4.10")
+    up_to_date.stubs(:latest_dokku_version).returns("v0.4.10")
+    assert up_to_date.up_to_date?, "Server should be marked as up to date"
+  end
 end


### PR DESCRIPTION
* Show a warning banner if the Dokku version is out of date
* Allow servers with dokku > 0.4.11 to auto update
* Servers with dokku < 0.4.11 need to manually update, show instructions

Fixes: #45