### PR TITLE
Only backup apps which backups enabled

### DIFF
--- a/app/jobs/schedule_automated_backups_job.rb
+++ b/app/jobs/schedule_automated_backups_job.rb
@@ -2,7 +2,7 @@ class ScheduleAutomatedBackupsJob < ActiveJob::Base
   queue_as :default
 
   def perform
-    App.all.each do |app|
+    App.where(backups_enabled: true).each do |app|
       BackupScheduler.new(app).execute(type: :automatic)
     end
   end

--- a/test/controllers/backups_controller_test.rb
+++ b/test/controllers/backups_controller_test.rb
@@ -13,7 +13,7 @@ class BackupsControllerTest < ActionController::TestCase
   end
 
   test "POST enable should mark the app as backup enabled" do
-    app = apps(:example)
+    app = apps(:example).tap { |app| app.update(backups_enabled: false) }
 
     refute app.backups_enabled?, "App should have backups disabled"
 

--- a/test/fixtures/apps.yml
+++ b/test/fixtures/apps.yml
@@ -3,7 +3,9 @@
 example:
   server: example
   name: Example app
+  backups_enabled: true
 
 local_app:
   server: local
   name: Local app
+  backups_enabled: false

--- a/test/jobs/schedule_automated_backups_job_test.rb
+++ b/test/jobs/schedule_automated_backups_job_test.rb
@@ -2,9 +2,9 @@ require 'test_helper'
 
 class ScheduleAutomatedBackupsJobTest < ActiveJob::TestCase
   test "#perform calls BackupScheduler for all apps" do
-    app_count = App.count
+    backups_enabled_count = App.where(backups_enabled: true).count
 
-    BackupScheduler.any_instance.expects(:execute).times(app_count)
+    BackupScheduler.any_instance.expects(:execute).times(backups_enabled_count)
     ScheduleAutomatedBackupsJob.perform_now
   end
 end


### PR DESCRIPTION
Currently we backup all the apps. But we only want to run scheduled backups for
apps on which we explicitly enabled it.

Fixes: #73

/cc @michiels / @brambokdam