### PR TITLE
Allow for real unattended upgrades

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,12 +10,16 @@ AllCops:
     - "bin/**/*"
     - "**/Rakefile"
     - "**/config.ru"
-  RunRailsCops: true
   DisplayCopNames: true
   StyleGuideCopsOnly: false
+  TargetRubyVersion: 2.3
+Rails:
+  Enabled: true
 Style/AndOr:
   EnforcedStyle: always
   Enabled: true
+Style/FrozenStringLiteralComment:
+  Enabled: false
 Style/CommentAnnotation:
   Keywords:
     - TODO

--- a/app/controllers/deploy_keys_controller.rb
+++ b/app/controllers/deploy_keys_controller.rb
@@ -11,11 +11,10 @@ class DeployKeysController < ServerBaseController
     if @deploy_key.save
       CreateDeployKeyJob.perform_later(@server, @deploy_key)
       flash[:success] = "Deploy key has been added"
-      redirect_to server_deploy_keys_path(@server)
     else
       flash[:error] = "Not all fields are filled in."
-      redirect_to server_deploy_keys_path(@server)
     end
+    redirect_to server_deploy_keys_path(@server)
   end
 
   def destroy

--- a/app/jobs/create_app_job.rb
+++ b/app/jobs/create_app_job.rb
@@ -2,17 +2,9 @@ class CreateAppJob < ActiveJob::Base
   queue_as :default
 
   def perform(app)
-    @app = app
     app.update(busy: true)
-    SshExecution.new(app.server).execute(command: "dokku apps:create #{app_name}")
+    SshExecution.new(app.server).execute(command: "dokku apps:create #{app.clean_name}")
+    SshExecution.new(app.server).execute(command: "dokku configs:unset #{app.clean_name} NO_VHOST")
     app.update(busy: false)
-  end
-
-  private
-
-  attr_reader :app
-
-  def app_name
-    app.name.parameterize
   end
 end

--- a/app/jobs/create_backup_job.rb
+++ b/app/jobs/create_backup_job.rb
@@ -24,7 +24,7 @@ class CreateBackupJob < ActiveJob::Base
   def run_backup
     SshExecution.new(app.server).execute(command: backup_command)
     SshExecution.new(app.server).scp(from: "/root/#{backup_name}",
-                                     to: Rails.root.join("backups", "#{app.clean_name}", backup_name))
+                                     to: Rails.root.join("backups", app.clean_name, backup_name))
     SshExecution.new(app.server).execute(command: "rm #{backup_name}")
   end
 

--- a/app/jobs/install_server_job.rb
+++ b/app/jobs/install_server_job.rb
@@ -34,6 +34,7 @@ class InstallServerJob < ActiveJob::Base
   def install_dokku
     "sudo echo 'dokku dokku/web_config boolean false' | debconf-set-selections && "\
       "sudo echo 'dokku dokku/vhost_enable boolean false' | debconf-set-selections && " \
+      "sudo echo 'dokku dokku/hostname string intercity.dokku' | debconf-set-selections && " \
       "sudo echo 'dokku dokku/skip_key_file boolean true' | debconf-set-selections && " \
       "wget https://raw.githubusercontent.com/dokku/dokku/#{server.latest_dokku_version}/bootstrap.sh && "\
       "sudo DOKKU_TAG=#{server.latest_dokku_version} bash bootstrap.sh"

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -29,7 +29,7 @@ class Server < ActiveRecord::Base
   end
 
   def latest_dokku_version
-    "v0.4.11".freeze
+    "v0.4.13".freeze
   end
 
   private


### PR DESCRIPTION
Currently the upgrader got stuck because it asked for the "Main users" SSH key file, which is not
really a requirement. I fixed this by sending a `Enter` (newline) to the server
when we get this question.