### PR TITLE
Redirect update button to the manual update page

### DIFF
--- a/app/views/servers/_outdated.html.erb
+++ b/app/views/servers/_outdated.html.erb
@@ -6,7 +6,7 @@
         Keep in mind that updating does cause a short downtime.</p>
     </div>
     <div class="col-md-2">
-      <%= link_to "Update", start_update_server_path(server), method: :post, class: "pull-right btn-sm btn btn-default" %>
+      <%= link_to "Update", manual_update_server_path(server), class: "pull-right btn-sm btn btn-default" %>
     </div>
   </div>
 </div>

--- a/app/views/servers/manual_update.html.erb
+++ b/app/views/servers/manual_update.html.erb
@@ -1,13 +1,8 @@
-<div class="text-center">
-    <h1>Can't automaticly update</h1>
-    <p>We can automaticly update your Dokku instance as of version <b>v0.4.11</b>, 
-    however you run version <b><%= @server.dokku_version %></b>.</p>
-    <p>To update your server, you need to manually SSH into the server, and run the following command:</p>
-    <p>
-      <pre>
+<h1>Can't automaticly update</h1>
+<p>To update your server, you need to manually SSH into the server, and run the following command:</p>
+<p>
+  <pre>
 sudo echo 'dokku dokku/web_config boolean false' | debconf-set-selections && sudo echo 'dokku dokku/vhost_enable boolean false' | debconf-set-selections && sudo echo 'dokku dokku/skip_key_file boolean true' | debconf-set-selections && sudo apt-get install -qq -y dokku
-      </pre>
-    </p>
-    <p>After you updated the server, it can take up to 30 minutes for Intercity to pick
-      up the updated version.</p>
-</div>
+  </pre>
+</p>
+<p>After you updated the server, it can take up to 30 minutes for Intercity to pick up the updated version.</p>


### PR DESCRIPTION
The automatic update is a bit buggy, this will always redirect the update button to the manual update page.

![screen shot 2016-03-04 at 15 11 30](https://cloud.githubusercontent.com/assets/5755430/13529262/8eb3ce3c-e21b-11e5-8102-aeb8fc74277a.png)