### PR TITLE
Use eager_load_path instead of autoload_paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ module IntercityNext
     config.generators.assets = false
     config.generators.helper = false
 
-    config.autoload_paths << Rails.root.join("lib")
+    config.eager_load_paths << Rails.root.join("lib")
 
     $redis = Redis.new
   end


### PR DESCRIPTION
`autoload_paths` has been removed in rails5, you should now use
`eager_load_paths`