### PR TITLE
Increase the database pool for production

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -15,3 +15,4 @@ production:
   <<: *default
   database: intercity
   host: <%= ENV["DB_SOCKET"] %>
+  pool: 50


### PR DESCRIPTION
Currently we are running with a pool of just 2, which is giving a lot of
connection issues now that we run the healthchecks.

Increase them to 50 to solve that issue.