### PR TITLE
Remove the last pointer to CommandAggregator

### DIFF
--- a/app/models/ssh_key_maintainer.rb
+++ b/app/models/ssh_key_maintainer.rb
@@ -29,10 +29,6 @@ class SshKeyMaintainer
     Rails.root.join("keys", key_filename)
   end
 
-  def command_aggregator
-    @command_aggregator ||= CommandAggregator.new
-  end
-
   def key_filename
     @key_filename ||= "#{server.id}_#{apply_stamp}_key_#{SecureRandom.hex(5)}"
   end


### PR DESCRIPTION
In the old version of IC we used the CommandAggregator to check what commands
have been run against a server. Since we are currently not using such a system.
Let's remove this from the codebase