### PR TITLE
Add fake SSH Executioner for tests

### DIFF
--- a/app/models/ssh_execution.rb
+++ b/app/models/ssh_execution.rb
@@ -1,4 +1,7 @@
 class SshExecution
+  class_attribute :executioner
+  self.executioner = Net::SSH
+
   def initialize(server)
     @server = server
   end
@@ -19,11 +22,11 @@ class SshExecution
 
   def execute_with_block
     ssh_key_maintainer.create_key_for_connection
-    Net::SSH.start(@server.ip, "root",
-                   port: 22,
-                   keys: [ssh_key_maintainer.key], paranoid: false,
-                   timeout: ssh_timeout,
-                   number_of_password_prompts: 0) do |ssh|
+    executioner.start(@server.ip, "root",
+                      port: 22,
+                      keys: [ssh_key_maintainer.key], paranoid: false,
+                      timeout: ssh_timeout,
+                      number_of_password_prompts: 0) do |ssh|
       yield ssh
     end
   ensure

--- a/test/jobs/health_check_job_test.rb
+++ b/test/jobs/health_check_job_test.rb
@@ -4,14 +4,14 @@ class HealthCheckJobTest < ActiveJob::TestCase
   test "#perform should call out to SshExecution to test if server is available" do
     server = servers(:example)
 
-    SshExecution.any_instance.expects(:execute).returns("0.4.6")
+    FakeSshExecutioner.return_value = "0.4.6"
     HealthCheckJob.perform_now(server)
   end
 
   test "#perform updates the dokku_version of the server if it is out of sync" do
     server = servers(:example).tap { |s| s.update(dokku_version: "0.4.6") }
 
-    SshExecution.any_instance.expects(:execute).returns("0.4.8")
+    FakeSshExecutioner.return_value = "0.4.8"
     HealthCheckJob.perform_now(server)
 
     assert_equal "v0.4.8", server.reload.dokku_version
@@ -20,7 +20,7 @@ class HealthCheckJobTest < ActiveJob::TestCase
   test "#perform should put the server in down state if we can't connect" do
     server = servers(:example).tap { |s| s.update(status: "up") }
 
-    SshExecution.any_instance.expects(:execute).raises(Errno::EHOSTDOWN)
+    FakeSshExecutioner.return_value = -> { raise Errno::EHOSTDOWN }
     HealthCheckJob.perform_now(server)
 
     assert_equal "down", server.reload.status

--- a/test/support/fake_ssh_executioner.rb
+++ b/test/support/fake_ssh_executioner.rb
@@ -1,0 +1,11 @@
+class FakeSshExecutioner
+  class_attribute :return_value
+
+  def self.start(ip, username, opt = {})
+    if return_value.respond_to?(:call)
+      return_value.call
+    else
+      return_value
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,6 +29,7 @@ class ActiveSupport::TestCase
 
   def setup
     DatabaseCleaner.start
+    SshExecution.executioner = FakeSshExecutioner
   end
 
   def teardown


### PR DESCRIPTION
Currently we have to stub out the entire `SshExecution` class, in order not to
actually try to hit a server.

By adding a `FakeSshExecutioner` as a stand-in for the actual lib, we can run
tests without hitting an external server, but still determine the result we want
to get back.

We can improve this later on by also recording what commands have been send to
the `FakeSshExecutioner`.