### PR TITLE
Redesign onboarding and show errors with fields

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,10 +7,8 @@
 //= require health_check
 //= require highlight
 //= require clipboard
+//= require form_errors
 //= require turbolinks
-
-$(function() {
-});
 
 $(document).on("turbolinks:load", function() {
   FastClick.attach(document.body);

--- a/app/assets/javascripts/form_errors.coffee
+++ b/app/assets/javascripts/form_errors.coffee
@@ -1,0 +1,21 @@
+$(document).on "turbolinks:load", ->
+  new FormErrorHandler().reset()
+  new FormErrorHandler().execute()
+
+class @window.FormErrorHandler
+  reset: ->
+    $(".control").each ->
+      $(this).find(".input").removeClass("is-danger")
+      $(this).find(".fa-warning").remove()
+      $(this).find(".help.is-danger").remove()
+  execute: ->
+    $(".field_with_errors").each ->
+      field = $(this).find(".input")
+      error_message = field.data("error")
+      parent_control = $(this).parent()
+
+      field.addClass("is-danger")
+      parent_control.addClass("has-icon").addClass("has-icon-right")
+      parent_control.append("<i class='fa fa-warning'></i>")
+      if error_message
+        parent_control.append("<span class='help is-danger'>#{error_message}</span>")

--- a/app/views/domains/_form.html.erb
+++ b/app/views/domains/_form.html.erb
@@ -1,7 +1,9 @@
 <div class="box">
   <h3 class="title">Add a new domain</h3>
   <%= form_for [@app.server, @app, @domain], remote: true do |f| %>
-    <%= f.text_field :name, placeholder: "Domain name", hide_label: true, class: "input control" %>
+    <div class="control">
+      <%= f.text_field :name, placeholder: "Domain name", hide_label: true, class: "input" %>
+    </div>
     <%= f.submit "Add", class: "button control is-primary" %>
   <% end %>
 </div>

--- a/app/views/domains/create.js.erb
+++ b/app/views/domains/create.js.erb
@@ -5,3 +5,5 @@
 <% else %>
   $('body').find("[data-role~=form]").html("<%= j render "form" %>");
 <% end %>
+new FormErrorHandler().reset()
+new FormErrorHandler().execute()

--- a/app/views/env_vars/_form.html.erb
+++ b/app/views/env_vars/_form.html.erb
@@ -1,8 +1,13 @@
 <div class="box">
   <h3 class="title">Add new env var</h3>
   <%= form_for [@app.server, @app, @env_var], remote: true do |f| %>
-    <%= f.text_field :key, placeholder: "Key", hide_label: true, class: "input control" %>
-    <%= f.text_field :value, placeholder: "Value", hide_label: true, class: "input control" %>
+    <div class="control">
+      <%= f.text_field :key, placeholder: "Key", hide_label: true, class: "input",
+        data: { error: @env_var.errors[:key].first } %>
+    </div>
+    <div class="control">
+      <%= f.text_field :value, placeholder: "Value", hide_label: true, class: "input" %>
+    </div>
     <%= f.submit "Add", class: "button is-primary" %>
   <% end %>
 </div>

--- a/app/views/env_vars/create.js.erb
+++ b/app/views/env_vars/create.js.erb
@@ -5,3 +5,5 @@
 <% else %>
   $('body').find("[data-role~=form]").html("<%= j render "form" %>");
 <% end %>
+new FormErrorHandler().reset()
+new FormErrorHandler().execute()

--- a/app/views/onboarding/index.html.erb
+++ b/app/views/onboarding/index.html.erb
@@ -1,18 +1,23 @@
-<div class="col-md-6 col-md-offset-3">
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title">Welcome to Intercity</h3>
-    </div>
-    <%= form_for @user, url: welcome_path do |f| %>
-      <div class="panel-body">
+<div class="columns">
+  <div class="column is-6 is-offset-3">
+    <div class="content box">
+      <h3>Welcome to Intercity</h3>
+      <%= form_for @user, url: welcome_path do |f| %>
         <p>Since this is the first time you start the app,
-        we ask you to create the first user account. After you have created your account, this page will be gone</p>
-          <%= f.text_field :email %>
-          <%= f.password_field :password %>
-      </div>
-      <div class="panel-footer">
-        <%= f.submit "Create first account", class: "btn btn-primary" %>
-      </div>
-    <% end %>
+        we ask you to create the first user account.
+        After you have created your account, this page will be gone</p>
+
+        <label class="label">Email</label>
+        <div class="control">
+          <%= f.text_field :email, class: "input", placeholder: "Email",
+            data: { error: @user.errors[:email].first } %>
+        </div>
+        <div class="control">
+          <%= f.password_field :password, class: "input", placeholder: "Password",
+            data: { error: @user.errors[:password].first } %>
+        </div>
+        <%= f.submit "Create first account", class: "button is-primary" %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/servers/test_ssh.js.erb
+++ b/app/views/servers/test_ssh.js.erb
@@ -2,6 +2,7 @@
     <% if @error.present? %>
       $("[data-server-status~=checking]").find(".hint").html("<%= @error %>").removeClass("is-hidden");
     <% end %>
+    console.log("sfsdf")
     new ServerPoller("<%= test_ssh_server_path(@server) %>").poll();
 <% elsif @server.connected? %>
   $("[data-server-status~=checking]").addClass("is-hidden");

--- a/app/views/servers/test_ssh.js.erb
+++ b/app/views/servers/test_ssh.js.erb
@@ -2,7 +2,6 @@
     <% if @error.present? %>
       $("[data-server-status~=checking]").find(".hint").html("<%= @error %>").removeClass("is-hidden");
     <% end %>
-    console.log("sfsdf")
     new ServerPoller("<%= test_ssh_server_path(@server) %>").poll();
 <% elsif @server.connected? %>
   $("[data-server-status~=checking]").addClass("is-hidden");

--- a/app/views/services/status.js.erb
+++ b/app/views/services/status.js.erb
@@ -2,7 +2,6 @@
     new ServerPoller("<%= status_server_service_path(@server, @service) %>").poll();
 <% else %>
     var service = $("#<%= dom_id(@service) %>");
-    console.log(service);
     service.find("[data-service-status~=installing]").addClass("hidden");
     service.find("[data-service-status~=installed]").removeClass("hidden");
     service.find(".panel").removeClass("service-installing").addClass("service-installed");

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,10 +1,10 @@
 <div class="box">
   <h1 class="subtitle">Add a new user</h1>
   <%= form_for @user, remote: true do |f| %>
-    <p class="control">
+    <div class="control">
       <%= f.text_field :email, placeholder: "E-mail address", hide_label: true,
-        class: "input is-medium #{"is-danger" if @user.errors.include?(:email)}" %>
-    </p>
+        class: "input", data: { error: @user.errors[:email].first } %>
+    </div>
     <p class="control">
     <%= f.submit "Add new user", class: "button is-primary" %>
     </p>

--- a/app/views/users/create.js.erb
+++ b/app/views/users/create.js.erb
@@ -5,3 +5,5 @@
 <% else %>
   $('body').find("[data-role~=form]").html("<%= j render "form" %>");
 <% end %>
+new FormErrorHandler().reset()
+new FormErrorHandler().execute()


### PR DESCRIPTION
**Redesign onboarding**
When we moved to Bulma we did forget to style the onboarding page. I added new
styling to that page

**Show errors with fields**
Before the Bulma upgrade, we used bootstrap and bootstrap-form gem. This was
making sure the fields where in red and with the error message near it. Since
we moved to Bulma, we did not show any feedback to the user when there was an
error.

I added styling for that case downside is, it has to be done with a splash of
JS. This is because of the complex'ish html structure for fields with errors in
Bulma

Fixes #118 

**Screenshot/gif**
![field-error](https://cloud.githubusercontent.com/assets/1362793/14938665/55bf6f04-0f2b-11e6-942f-097cdb243ece.gif)
