### PR TITLE
Flash messages bulma style

### DIFF
--- a/app/helpers/flash_messages_helper.rb
+++ b/app/helpers/flash_messages_helper.rb
@@ -1,14 +1,14 @@
 module FlashMessagesHelper
-  def bootstrap_class_for(flash_type)
+  def bulma_class_for(flash_type)
     case flash_type
     when "success"
-      "alert-success"
+      "is-success"
     when "error"
-      "alert-danger"
+      "is-danger"
     when "alert"
-      "alert-danger"
+      "is-danger"
     when "notice"
-      "alert-info"
+      "is-info"
     else
       flash_type
     end
@@ -16,8 +16,8 @@ module FlashMessagesHelper
 
   def flash_messages
     flash.map do |msg_type, message|
-      content_tag(:div, class: "alert #{bootstrap_class_for(msg_type)}") do
-        content_tag(:button, "x", class: "close", data: { dismiss: "alert" }) + message
+      content_tag(:div, class: "notification #{bulma_class_for(msg_type)}") do
+        content_tag(:button, "", class: "delete") + message
       end
     end.join.html_safe
   end


### PR DESCRIPTION
The flash messages where in a Bootstrap format and broken when we started using Bulma.

Fixes: https://github.com/intercity/intercity-next/issues/133

<img width="394" alt="screen shot 2016-05-11 at 14 40 11" src="https://cloud.githubusercontent.com/assets/5755430/15181274/9bfecab0-1786-11e6-97db-be61c5a4306a.png">
