### PR TITLE
Service polling broken.

### DIFF
--- a/app/views/services/status.js.erb
+++ b/app/views/services/status.js.erb
@@ -2,7 +2,7 @@
     new ServerPoller("<%= status_server_service_path(@server, @service) %>").poll();
 <% else %>
     var service = $("#<%= dom_id(@service) %>");
-    service.find("[data-service-status~=installing]").addClass("hidden");
-    service.find("[data-service-status~=installed]").removeClass("hidden");
+    service.find("[data-service-status~=installing]").addClass("is-hidden");
+    service.find("[data-service-status~=installed]").removeClass("is-hidden");
     service.find(".panel").removeClass("service-installing").addClass("service-installed");
 <% end %>


### PR DESCRIPTION
In Bulma we use `is-hidden` to hide a element in the JS we used the old bootstrap `hidden` syntax. So the wrong element was added and removed.

Fixes: https://github.com/intercity/intercity-next/issues/127