### PR TITLE
Update Intercity to Dokku 0.7.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,6 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 v 0.0.1 (unreleased)
 * Move generation of SECRET_KEY_TOKEN to an initializer (jvanbaarsen)
-* Update to Dokku 0.5.6 (jvanbaarsen)
 * Brand new design (jvanbaarsen)
 * Scope app name uniqueness to server and not entire IC (jvanbaarsen)
 * Make sure service containers are destroyed when removing an app Fixes: #80 (jvanbaarsen)
@@ -15,3 +14,4 @@ v 0.0.1 (unreleased)
 * Ensure Healthcheck page has proper styling (jvanbaarsen)
 * Don't schedule backups when the server is marked as down (jvanbaarsen)
 * Add pagination to the backups page (jvanbaarsen)
+* Update to Dokku 0.7.0; Fixes: #158 (jvanbaarsen)

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -31,7 +31,7 @@ class Server < ActiveRecord::Base
   end
 
   def latest_dokku_version
-    "v0.5.6".freeze
+    "v0.7.0".freeze
   end
 
   private


### PR DESCRIPTION
All new servers will now be installed with Dokku 0.7.0.

Fixes: #158