### PR TITLE
Redesign / Improve env var page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,7 +7,7 @@
 //= require health_check
 //= require highlight
 //= require clipboard
-//= require form_errors
+//= require forms
 //= require modal
 //= require turbolinks
 

--- a/app/assets/javascripts/forms.coffee
+++ b/app/assets/javascripts/forms.coffee
@@ -1,3 +1,6 @@
+$(document).on "click", "[data-behaviour~=select-text]", ->
+  $(this).select()
+
 $(document).on "turbolinks:load", ->
   new FormErrorHandler().reset()
   new FormErrorHandler().execute()

--- a/app/assets/stylesheets/_env-vars.scss
+++ b/app/assets/stylesheets/_env-vars.scss
@@ -1,0 +1,23 @@
+.env-vars {
+  tr {
+    &:hover {
+      background: none;
+    }
+  }
+
+  .env-var {
+    .actions {
+      .button {
+        &.is-link {
+          text-decoration: none;
+          color: auto;
+          font-size: 1.2em;
+
+          &:hover {
+            background: darken($grey-lighter, 6.0);
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,0 +1,6 @@
+.input {
+  &.disabled {
+    background: lighten($grey-lighter, 1.5);
+    cursor: not-allowed;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,10 +5,12 @@
 @import "font-awesome-sprockets";
 @import "font-awesome";
 @import "layout";
+@import "forms";
 @import "login";
 @import "servers";
 @import "apps";
 @import "services";
 @import "help";
+@import "env-vars";
 @import "highlight/github.min";
 @import "tooltip";

--- a/app/views/env_vars/_env_var.html.erb
+++ b/app/views/env_vars/_env_var.html.erb
@@ -1,7 +1,9 @@
 <%= content_tag :tr, id: dom_id(env_var), class: "env-var" do %>
-  <td><%= env_var.key %></td>
-  <td><%= env_var.value %></td>
-  <td class="actions"><%= link_to "delete",
+  <td><%= text_field_tag :key, env_var.key, readonly: true, class: "input disabled",
+    data: { behaviour: "select-text" } %></td>
+  <td><%= text_field_tag :value, env_var.value, readonly: true, class: "input disabled",
+    data: { behaviour: "select-text" } %></td>
+  <td class="actions"><%= link_to icon("trash"),
     server_app_env_var_path(env_var.app.server, env_var.app, env_var),
-    remote: true, method: :delete %></td>
+    remote: true, method: :delete, class: "button is-link" %></td>
 <% end %>

--- a/app/views/env_vars/index.html.erb
+++ b/app/views/env_vars/index.html.erb
@@ -1,7 +1,7 @@
 <%= render "apps/heading", app: @app, tab: "env_vars" %>
 <div class="columns">
   <div class="column is-8">
-    <table class="table is-striped env-vars">
+    <table class="table env-vars">
       <thead>
         <tr>
           <th>Key</th>


### PR DESCRIPTION
Currently there is a problem where environment variables which are super long
are ruining the layout.

With this fix the env vars are shown in a disabled text field, with a cursor
indicating that it is just read only. When you click the field, it will select
the content within for easy copying.

Fixes: #155

**Screenshot**
![image](https://cloud.githubusercontent.com/assets/1362793/17849763/9a2fc12e-685a-11e6-9283-9cfb4ecb209a.png)
