### PR TITLE
When linking a service to an app, I want to get more feedback

### DIFF
--- a/app/controllers/app_services_controller.rb
+++ b/app/controllers/app_services_controller.rb
@@ -9,6 +9,11 @@ class AppServicesController < ServerBaseController
     @app.services << @service
 
     LinkServiceToAppJob.perform_later(@app, @service)
-    redirect_to server_app_path(@app.server, @app)
+    redirect_to server_app_services_path(@app.server, @app)
+  end
+
+  def status
+    @app = Server.find(params[:server_id]).apps.find(params[:app_id])
+    @service = Service.find(params[:id])
   end
 end

--- a/app/jobs/link_service_to_app_job.rb
+++ b/app/jobs/link_service_to_app_job.rb
@@ -6,5 +6,6 @@ class LinkServiceToAppJob < ActiveJob::Base
     link_command = service.commands["link"].gsub(/%app_name%/, app.clean_name)
     SshExecution.new(app.server).execute(command: create_command)
     SshExecution.new(app.server).execute(command: link_command)
+    app.linked_service(service).update(status: "installed")
   end
 end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -13,7 +13,19 @@ class App < ActiveRecord::Base
     name.parameterize
   end
 
-  def service?(service)
+  def linked_service?(service)
     services.include?(service)
+  end
+
+  def service_status(service)
+    if linked_service?(service)
+      linked_service(service).status
+    else
+      "new"
+    end
+  end
+
+  def linked_service(service)
+    linked_services.find_by!(service: service)
   end
 end

--- a/app/models/linked_service.rb
+++ b/app/models/linked_service.rb
@@ -1,4 +1,6 @@
 class LinkedService < ActiveRecord::Base
   belongs_to :app
   belongs_to :service
+
+  enum status: { installing: 0, installed: 1 }
 end

--- a/app/views/app_services/_service.html.erb
+++ b/app/views/app_services/_service.html.erb
@@ -4,11 +4,23 @@
     <p class="has-text-centered">
       <%= image_tag "services/#{service.name.downcase}.png", width: 100, height: 100 %>
     </p>
-    <% if app.service?(service) %>
-      <p class="has-text-centered"><span class="tag is-success">Linked</span></p>
-    <% else %>
-      <p class="has-text-centered"><%= link_to "Link #{service.name}", server_app_service_path(app.server, app, service),
+    <p class="has-text-centered <%= "is-hidden" unless app.service_status(service) == "installed" %>" data-service-status="installed">
+      <span class="tag is-success">Linked</span>
+    </p>
+
+    <p class="has-text-centered <%= "is-hidden" unless app.service_status(service) == "installing" %>" data-service-status="installing">
+      <span class="tag is-warning">Linking</span>
+    </p>
+
+    <p class="has-text-centered <%= "is-hidden" unless app.service_status(service) == "new" %>" data-service-status="new">
+      <%= link_to "Link #{service.name}", server_app_service_path(app.server, app, service),
         method: :post, class: "button is-primary" %></p>
-    <% end %>
+    </p>
   </div>
 <% end %>
+
+<script>
+<% if app.service_status(service) == "installing" %>
+  new ServerPoller("<%= status_server_app_service_path(app.server, app, service) %>").poll();
+<% end %>
+</script>

--- a/app/views/app_services/index.html.erb
+++ b/app/views/app_services/index.html.erb
@@ -5,6 +5,21 @@
     <p><%= link_to "Install a service", server_services_path(@app.server), class: "button is-primary" %>
   </div>
 <% else %>
+  <section class="hero is-small is-primary is-bold">
+    <div class="hero-body has-text-centered">
+      <div class="container">
+        <h1 class="title">
+          Linked services
+        </h1>
+        <h2 class="subtitle">
+          In order to use a service you installed on your server,
+          you need to link it to your app.<br/>
+          On this page you can see all the installed services for this server,
+          and if they are linked to your app.
+        </h2>
+      </div>
+    </div>
+  </section>
   <div class="services">
     <div class="columns">
     <%= render partial: "app_services/service", collection: @app.server.services,

--- a/app/views/app_services/status.js.erb
+++ b/app/views/app_services/status.js.erb
@@ -1,0 +1,7 @@
+<% if @app.service_status(@service) == "installing" %>
+    new ServerPoller("<%= status_server_app_service_path(@app.server, @app, @service) %>").poll();
+<% else %>
+    var service = $("#<%= dom_id(@service) %>");
+    service.find("[data-service-status~=installing]").addClass("is-hidden");
+    service.find("[data-service-status~=installed]").removeClass("is-hidden");
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
     resources :apps, only: [:index, :new, :create, :destroy, :show] do
       resources :services, controller: "app_services", only: :index do
         post :create, on: :member
+        get :status, on: :member
       end
       resources :env_vars, only: [:index, :create, :destroy]
       resources :domains, only: [:index, :create, :destroy]

--- a/db/migrate/20160830085425_add_status_to_linked_service.rb
+++ b/db/migrate/20160830085425_add_status_to_linked_service.rb
@@ -1,0 +1,5 @@
+class AddStatusToLinkedService < ActiveRecord::Migration[5.0]
+  def change
+    add_column :linked_services, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160829115818) do
+ActiveRecord::Schema.define(version: 20160830085425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,8 +75,9 @@ ActiveRecord::Schema.define(version: 20160829115818) do
   create_table "linked_services", force: :cascade do |t|
     t.integer  "app_id"
     t.integer  "service_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.integer  "status",     default: 0
     t.index ["app_id"], name: "index_linked_services_on_app_id", using: :btree
     t.index ["service_id"], name: "index_linked_services_on_service_id", using: :btree
   end

--- a/test/models/app_test.rb
+++ b/test/models/app_test.rb
@@ -10,4 +10,25 @@ class AppTest < ActiveSupport::TestCase
 
   should validate_presence_of :name
   should validate_uniqueness_of(:name).scoped_to(:server_id)
+
+  test "#service_status(service) returns a status code for the service" do
+    app = apps(:example).tap { |a| a.services.destroy_all }
+    redis = services(:redis)
+
+    assert_equal "new", app.service_status(redis)
+
+    app.services << redis
+    assert_equal "installing", app.service_status(redis)
+
+    LinkedService.find_by(app: app, service: redis).update(status: "installed")
+    assert_equal "installed", app.service_status(redis)
+  end
+
+  test "#linked_service(service) gets the given service type" do
+    app = apps(:example)
+    redis = services(:redis)
+    redis_example = linked_services(:redis_example)
+
+    assert_equal redis_example, app.linked_service(redis)
+  end
 end


### PR DESCRIPTION
Currently we just redirect the user back to the App overview page, and directly
mark the service as linked. This is not true, since linking a service can take
anywhere between a second up to 30 seconds or more.

In the new situation we show the user that we are linking the service, and poll
to see if the service has been linked.

Fixes: #8