### PR TITLE
Mark existing linked services as Installed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 Please view this file on the master branch, on stable branches it's out of date.
 
+Unreleased
+* Mark all existing services as linked (jvanbaarsen)
+
 v 0.1.0 * 2016-09-02
 * Move generation of SECRET_KEY_TOKEN to an initializer (jvanbaarsen)
 * Brand new design (jvanbaarsen)

--- a/db/migrate/20160902131047_mark_existing_services_as_linked.rb
+++ b/db/migrate/20160902131047_mark_existing_services_as_linked.rb
@@ -1,0 +1,6 @@
+class MarkExistingServicesAsLinked < ActiveRecord::Migration[5.0]
+  def change
+    # Mark all legacy linked services as linked (We did not keep track of status)
+    LinkedService.update_all(status: 1)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160901100859) do
+ActiveRecord::Schema.define(version: 20160902131047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
We did not keep track of the status of a linked service before. Since we do
it now, and the default status is 0, all existing services are marked as
Not Linked. In order to have them show up as linked, we need to update them
all.