### PR TITLE
Ensure we give curl enough time to download buildpacks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Unreleased
 * Mark all existing services as linked (jvanbaarsen)
 * Store the amount of resources a server has (jvanbaarsen)
 * Update Dokku to 0.7.1 (jvanbaarsen)
+* Ensure we give CURL enough time to download buildpacks (jvanbaarsen)
 
 v 0.1.0 * 2016-09-02
 * Move generation of SECRET_KEY_TOKEN to an initializer (jvanbaarsen)

--- a/app/jobs/install_server_job.rb
+++ b/app/jobs/install_server_job.rb
@@ -9,6 +9,9 @@ class InstallServerJob < ActiveJob::Base
 
     server.update(status: "up")
     ServerResourceGatherer.new(server).execute
+
+    # Ensure we give Curl enough time to download buildpacks
+    SshExecution.new(server).execute(command: "dokku config:set --global CURL_TIMEOUT=300")
   end
 
   private


### PR DESCRIPTION
In some cased downloading buildpacks can take some time (because they download
with 30kb/s). The default timeout is set to 30 seconds. This increases that
timeout to 5 minutes.

Fixes: #11