### PR TITLE
Allow server to be installed as other user then root

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 Please view this file on the master branch, on stable branches it's out of date.
 
+Unreleased
+* Allow execution user to be set for a server, defaults to root Fixes: #94 (jvanbaarsen)
+
 V 0.2.0 * 2016-09-19
 * Mark all existing services as linked (jvanbaarsen)
 * Store the amount of resources a server has (jvanbaarsen)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-BOX_NAME = ENV["BOX_NAME"] || "bento/ubuntu-14.04"
+BOX_NAME = ENV["BOX_NAME"] || "bento/ubuntu-16.04"
 BOX_MEMORY = ENV["BOX_MEMORY"] || "1024"
 DOKKU_DOMAIN = ENV["DOKKU_DOMAIN"] || "dokku.me"
 DOKKU_IP = ENV["DOKKU_IP"] || "10.0.0.3"

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -77,7 +77,7 @@ class ServersController < ApplicationController
   private
 
   def server_params
-    params.require(:server).permit(:name, :ip)
+    params.require(:server).permit(:name, :username, :ip)
   end
 
   def set_server

--- a/app/jobs/create_backup_job.rb
+++ b/app/jobs/create_backup_job.rb
@@ -23,7 +23,7 @@ class CreateBackupJob < ActiveJob::Base
 
   def run_backup
     SshExecution.new(app.server).execute(command: backup_command)
-    SshExecution.new(app.server).scp(from: "/root/#{backup_name}",
+    SshExecution.new(app.server).scp(from: "/#{app.server.username}/#{backup_name}",
                                      to: Rails.root.join("backups", app.clean_name, backup_name))
     SshExecution.new(app.server).execute(command: "rm #{backup_name}")
   end

--- a/app/jobs/disable_swap_job.rb
+++ b/app/jobs/disable_swap_job.rb
@@ -26,6 +26,6 @@ class DisableSwapJob < ApplicationJob
   end
 
   def swap_file
-    "/root/disable_swap.sh"
+    "/#{server.username}/disable_swap.sh"
   end
 end

--- a/app/jobs/enable_ssl_job.rb
+++ b/app/jobs/enable_ssl_job.rb
@@ -21,15 +21,15 @@ class EnableSSLJob < ApplicationJob
   end
 
   def server_cert_path
-    "/root/#{app.clean_name}.server.crt"
+    "/#{app.server.username}/#{app.clean_name}.server.crt"
   end
 
   def server_key_path
-    "/root/#{app.clean_name}.server.key"
+    "/#{app.server.username}/#{app.clean_name}.server.key"
   end
 
   def server_tar_path
-    "/root/#{app.clean_name}.cert.tar"
+    "/#{app.server.username}/#{app.clean_name}.cert.tar"
   end
 
   def copy_file(from:, to:)

--- a/app/jobs/enable_swap_job.rb
+++ b/app/jobs/enable_swap_job.rb
@@ -26,6 +26,6 @@ class EnableSwapJob < ApplicationJob
   end
 
   def swap_file
-    "/root/enable_swap.sh"
+    "/#{server.username}/enable_swap.sh"
   end
 end

--- a/app/jobs/install_server_job.rb
+++ b/app/jobs/install_server_job.rb
@@ -19,10 +19,10 @@ class InstallServerJob < ActiveJob::Base
   attr_reader :server
 
   def install_dokku
-    "sudo echo 'dokku dokku/web_config boolean false' | debconf-set-selections && "\
-      "sudo echo 'dokku dokku/vhost_enable boolean false' | debconf-set-selections && " \
-      "sudo echo 'dokku dokku/hostname string intercity.dokku' | debconf-set-selections && " \
-      "sudo echo 'dokku dokku/skip_key_file boolean true' | debconf-set-selections && " \
+    "sudo echo 'dokku dokku/web_config boolean false' | sudo debconf-set-selections && "\
+      "sudo echo 'dokku dokku/vhost_enable boolean false' | sudo debconf-set-selections && " \
+      "sudo echo 'dokku dokku/hostname string intercity.dokku' | sudo debconf-set-selections && " \
+      "sudo echo 'dokku dokku/skip_key_file boolean true' | sudo debconf-set-selections && " \
       "wget https://raw.githubusercontent.com/dokku/dokku/#{server.latest_dokku_version}/bootstrap.sh && "\
       "sudo DOKKU_TAG=#{server.latest_dokku_version} bash bootstrap.sh"
   end
@@ -30,17 +30,16 @@ class InstallServerJob < ActiveJob::Base
   def perform_installation
     SshExecution.new(server).execute_with_block do |ssh|
       ssh.open_channel do |channel|
-        channel.exec install_dokku do |exec_channel, _|
-          exec_channel.on_data do |_, data|
-            if data =~ /Initial apt-get update/
-              server.update(install_step: 1)
-            elsif data =~ /Installing docker/
-              server.update(install_step: 2)
-            elsif data =~ /Installing dokku/
-              server.update(install_step: 3)
-            elsif data =~ /Importing herokuish into docker/
-              server.update(install_step: 4)
-            end
+        channel.exec install_dokku
+        channel.on_data do |_, data|
+          if data =~ /Initial apt-get update/
+            server.update(install_step: 1)
+          elsif data =~ /Installing docker/
+            server.update(install_step: 2)
+          elsif data =~ /Installing dokku/
+            server.update(install_step: 3)
+          elsif data =~ /Importing herokuish into docker/
+            server.update(install_step: 4)
           end
         end
       end

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -8,7 +8,7 @@ class Server < ActiveRecord::Base
 
   enum status: { fresh: 0, connected: 10, installing: 20, up: 30, down: 40 }
 
-  validates :name, :ip, presence: true
+  validates :name, :ip, :username, presence: true
 
   def service?(service)
     services.include?(service)

--- a/app/models/ssh_execution.rb
+++ b/app/models/ssh_execution.rb
@@ -16,9 +16,11 @@ class SshExecution
     ssh_key_maintainer.create_key_for_connection
     case direction
     when :upload
-      cmd = "scp -oStrictHostKeyChecking=no -i #{ssh_key_maintainer.key} #{from} root@#{@server.ip}:#{to}"
+      # rubocop:disable Metrics/LineLength
+      cmd = "scp -oStrictHostKeyChecking=no -i #{ssh_key_maintainer.key} #{from} #{@server.username}@#{@server.ip}:#{to}"
     else
-      cmd = "scp -oStrictHostKeyChecking=no -i #{ssh_key_maintainer.key} root@#{@server.ip}:#{from} #{to}"
+      cmd = "scp -oStrictHostKeyChecking=no -i #{ssh_key_maintainer.key} #{@server.username}@#{@server.ip}:#{from} #{to}"
+      # rubocop:enable Metrics/LineLength
     end
     system(cmd)
   ensure
@@ -27,7 +29,7 @@ class SshExecution
 
   def execute_with_block
     ssh_key_maintainer.create_key_for_connection
-    executioner.start(@server.ip, "root",
+    executioner.start(@server.ip, @server.username,
                       port: 22,
                       keys: [ssh_key_maintainer.key], paranoid: false,
                       timeout: ssh_timeout,

--- a/app/views/servers/_new.html.erb
+++ b/app/views/servers/_new.html.erb
@@ -6,10 +6,19 @@
       <a class="delete" data-behaviour="close-modal"></a>
     </header>
     <section class="modal-card-body">
+      <%= f.label :name, class: "label" %>
       <div class="control">
         <%= f.text_field :name, class: "input", placeholder: "Name",
           data: { error: @server.errors[:name].first } %>
       </div>
+
+      <%= f.label :username, class: "label", value: "Username for the root user" %>
+      <div class="control">
+        <%= f.text_field :username, class: "input", placeholder: "Username",
+          data: { error: @server.errors[:username].first } %>
+      </div>
+
+      <%= f.label :ip, class: "label", value: "IP Address" %>
       <div class="control">
         <%= f.text_field :ip, class: "input", placeholder: "IP Address",
           data: { error: @server.errors[:ip].first } %>

--- a/db/migrate/20161123123228_add_user_to_server.rb
+++ b/db/migrate/20161123123228_add_user_to_server.rb
@@ -1,0 +1,5 @@
+class AddUserToServer < ActiveRecord::Migration[5.0]
+  def change
+    add_column :servers, :username, :string, default: "root"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160908115429) do
+ActiveRecord::Schema.define(version: 20161123123228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,8 +88,8 @@ ActiveRecord::Schema.define(version: 20160908115429) do
   create_table "servers", force: :cascade do |t|
     t.string   "name"
     t.string   "ip"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.text     "rsa_key_public"
     t.text     "rsa_key_private"
     t.boolean  "connected",       default: false
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(version: 20160908115429) do
     t.integer  "total_ram"
     t.integer  "total_disk"
     t.integer  "total_cpu"
+    t.string   "username",        default: "root"
   end
 
   create_table "services", force: :cascade do |t|


### PR DESCRIPTION
Sometimes you don't want your server to run as root user, this PR adds a way to
set the user when creating a new server. To make it simple for "normal" usage,
we default to root.

Fixes: #94