### PR TITLE
Fix typo in production.rb

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 V 0.5.0 * TBD
 * Updated rails to 5.1 and ruby to 2.4.2 (jvanbaarsen)
+* Fix typo bug in production.rb preventing the app to start (jvanbaarsen)
 
 V 0.4.0 * 2017-12-01
 * When no Dokku installed, make sure version check is not breaking. Fixes #229 (jvanbaarsen)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,7 +89,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_option = { host: ENV["HOSTNAME"] }
+  config.action_mailer.default_url_options = { host: ENV["HOSTNAME"] }
   config.action_mailer.delivery_method = :smtp
   config.x.default_email_delivery_method = :sendmail
 end


### PR DESCRIPTION
When upgrading to Rails 5 I made a mistake in production.rb. This was
preventing the app to start.