### PR TITLE
Initial attempt at Docker package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:2.4.1
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash
+RUN mkdir /myapp
+WORKDIR /myapp
+ADD Gemfile /myapp/Gemfile
+ADD Gemfile.lock /myapp/Gemfile.lock
+RUN bundle install
+ADD . /myapp
+ENV APP_HOST=127.0.0.1
+RUN bundle exec rake assets:precompile
+CMD bundle exec rails s

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,10 +1,13 @@
 require 'securerandom'
 
-token = $redis.get("SECRET_KEY_BASE")
-if token.nil?
-  token = SecureRandom.hex(64)
-  $redis.set("SECRET_KEY_BASE", token)
-end
+token = SecureRandom.hex(64)
 
-Rails.application.config.secret_token = token
-Rails.application.config.secret_key_base = token
+begin
+  token = Redis.current.get("SECRET_KEY_BASE")
+  if token.nil?
+    Redis.current.set("SECRET_KEY_BASE", token)
+  end
+rescue
+  Rails.application.config.secret_token = token
+  Rails.application.config.secret_key_base = token
+end

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -3,11 +3,15 @@ require 'securerandom'
 token = SecureRandom.hex(64)
 
 begin
-  token = Redis.current.get("SECRET_KEY_BASE")
-  if token.nil?
+  current_token = Redis.current.get("SECRET_KEY_BASE")
+  if current_token.blank?
     Redis.current.set("SECRET_KEY_BASE", token)
+  else
+    token = current_token
   end
-rescue
-  Rails.application.config.secret_token = token
-  Rails.application.config.secret_key_base = token
+rescue => e
+  puts e.inspect
 end
+
+Rails.application.config.secret_token = token
+Rails.application.config.secret_key_base = token

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,6 @@
 ---
 :concurrency: 5
 :pidfile: tmp/sidekiq.pid
-:logfile: log/sidekiq.log
 production:
   :concurrency: 20
 :queues:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  db:
+    image: postgres
+  redis:
+    image: redis
+  web:
+    build: .
+    command: bundle exec rails s
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+      - redis
+    environment:
+      - RAILS_ENV=production
+      - DATABASE_URL=postgresql://postgres:@db:5432/intercity
+      - RAILS_SERVE_STATIC_FILES=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,40 @@ version: '3'
 services:
   db:
     image: postgres
+    volumes:
+      - pg-data:/var/lib/postgresql/data
   redis:
     image: redis
+    volumes:
+      - redis-data:/data
   web:
     build: .
     command: bundle exec rails s
-    ports:
-      - "3000:3000"
     depends_on:
       - db
       - redis
     environment:
       - RAILS_ENV=production
       - DATABASE_URL=postgresql://postgres:@db:5432/intercity
+      - SECRET_KEY_BASE=a
       - RAILS_SERVE_STATIC_FILES=true
+      - REDIS_URL=redis://redis:6379
+      - HOSTNAME=intercity.example.com
+      - RAILS_LOG_TO_STDOUT=true
+  sidekiq:
+    image: intercitynext_web
+    command: bundle exec sidekiq -q default -q mailers -q health_checks
+    environment:
+      - RAILS_ENV=production
+      - DATABASE_URL=postgresql://postgres:@db:5432/intercity
+      - REDIS_URL=redis://redis:6379
+      - SECRET_KEY_BASE=a
+      - RAILS_SERVE_STATIC_FILES=true
+      - HOSTNAME=intercity.example.com
+      - RAILS_LOG_TO_STDOUT=true
+    depends_on:
+      - db
+      - redis
+volumes:
+  pg-data:
+  redis-data:


### PR DESCRIPTION
This PR contains an initial prototype to package Intercity as a Docker stack. A simple Dockerfile has been added for hosting regular Rails apps with asset compilation. A docker-compose.yml file is added so that you can set up a full Intercity + Redis + Postgres stack while developing, but this can also be used while deploying.

The deployment direction this PR introduces in the future would be as follows:

1. We publish intercity-next contaimer images to Docker Hub/store on every release.
2. We provide a docker-compose.yml file (possibily as part of intercity-cli) to launch an Intercity instance which will pull down Redis, Postgres and run Intercity + the Sidekiq worker inside Intercity container.

How you can already use this PR:

1. Install Docker for your platform. The official Docker Mac client is great.
2. Start a local development Stack via:

    ```
    docker-compose run web rake db:create
    docker-compose run web rake db:schema:load
    docker-compose up
    ```

3. Profit and view  your local Intercity instance on http://localhost:3000

Happy to further discuss how we could take this further and what additional tooling/scripts/CLIs we might want to offer for easy installation and upgrading. I can imagine that:

```
intercity-server install
```

can just use docker-compose under the hood to get an Intercity environment up&running on a server.