### PR TITLE
Run certain commands as sudo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 V 0.5.0 * TBD
 * Updated rails to 5.1 and ruby to 2.4.2 (jvanbaarsen)
 * Fix typo bug in production.rb preventing the app to start (jvanbaarsen)
+* Make sure we run certain commands as sudo (jvanbaarsen)
 
 V 0.4.0 * 2017-12-01
 * When no Dokku installed, make sure version check is not breaking. Fixes #229 (jvanbaarsen)

--- a/app/jobs/create_deploy_key_job.rb
+++ b/app/jobs/create_deploy_key_job.rb
@@ -3,6 +3,6 @@ class CreateDeployKeyJob < ApplicationJob
 
   def perform(server, deploy_key)
     SshExecution.new(server).execute(command: "echo '#{deploy_key.key}' | " \
-                                     "sshcommand acl-add dokku #{deploy_key.name}")
+                                     "sudo sshcommand acl-add dokku #{deploy_key.name}")
   end
 end

--- a/app/jobs/delete_deploy_key_job.rb
+++ b/app/jobs/delete_deploy_key_job.rb
@@ -2,6 +2,6 @@ class DeleteDeployKeyJob < ApplicationJob
   queue_as :default
 
   def perform(server, deploy_key_name)
-    SshExecution.new(server).execute(command: "sshcommand acl-remove dokku #{deploy_key_name}")
+    SshExecution.new(server).execute(command: "sudo sshcommand acl-remove dokku #{deploy_key_name}")
   end
 end

--- a/app/jobs/disable_swap_job.rb
+++ b/app/jobs/disable_swap_job.rb
@@ -26,6 +26,6 @@ class DisableSwapJob < ApplicationJob
   end
 
   def swap_file
-    "/#{server.username}/disable_swap.sh"
+    "/#{'home/' unless server.username == 'root'}#{server.username}/disable_swap.sh"
   end
 end

--- a/app/jobs/disable_swap_job.rb
+++ b/app/jobs/disable_swap_job.rb
@@ -18,7 +18,7 @@ class DisableSwapJob < ApplicationJob
   end
 
   def disable_swap
-    SshExecution.new(server).execute(command: "sh #{swap_file}")
+    SshExecution.new(server).execute(command: "sudo sh #{swap_file}")
   end
 
   def remove_swap_script

--- a/app/jobs/enable_swap_job.rb
+++ b/app/jobs/enable_swap_job.rb
@@ -18,7 +18,7 @@ class EnableSwapJob < ApplicationJob
   end
 
   def enable_swap
-    SshExecution.new(server).execute(command: "sh #{swap_file}")
+    SshExecution.new(server).execute(command: "sudo sh #{swap_file}")
   end
 
   def remove_swap_script

--- a/app/jobs/enable_swap_job.rb
+++ b/app/jobs/enable_swap_job.rb
@@ -26,6 +26,6 @@ class EnableSwapJob < ApplicationJob
   end
 
   def swap_file
-    "/#{server.username}/enable_swap.sh"
+    "/#{'home/' unless server.username == 'root'}#{server.username}/enable_swap.sh"
   end
 end


### PR DESCRIPTION
We currently support running Intercity as another user then `root`. One
issue that comes from this, is that the `intercity` user needs to run some
commands as `sudo` in order for them to be successful.

This adds a fix for thise commands.

Fixes: #224