### PR TITLE
Convert to Selenium Webdriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,11 +42,11 @@ end
 
 group :development, :test do
   gem "awesome_print"
+  gem "capybara"
+  gem "chromedriver-helper"
   gem "dotenv-rails", "2.2.1"
   gem "rubocop"
   gem "selenium-webdriver"
-  gem "capybara"
-  gem "chromedriver-helper"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ group :development, :test do
   gem "awesome_print"
   gem "dotenv-rails", "2.2.1"
   gem "rubocop"
+  gem "selenium-webdriver"
+  gem "capybara"
+  gem "chromedriver-helper"
 end
 
 group :test do
@@ -52,7 +55,6 @@ group :test do
   gem "launchy"
   gem "minitest-reporters"
   gem "mocha"
-  gem "poltergeist"
   gem "shoulda"
   gem "timecop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
     ansi (1.5.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.3.0)
     awesome_print (1.8.0)
@@ -67,16 +69,21 @@ GEM
     capistrano-rails-console (2.2.1)
       capistrano (>= 3.5.0, < 4.0.0)
       sshkit-interactive (~> 0.2.0)
-    capybara (2.16.1)
+    capybara (3.10.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (~> 2.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (2.1.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     chronic (0.10.2)
     chunky_png (1.3.8)
-    cliver (0.3.2)
     codeclimate-test-reporter (1.0.8)
       simplecov (<= 0.13)
     coffee-rails (4.2.2)
@@ -113,6 +120,7 @@ GEM
       activesupport (>= 3.0)
       loofah (>= 2.0)
       nokogiri (>= 1.6)
+    io-like (0.3.0)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -174,10 +182,6 @@ GEM
     parser (2.4.0.2)
       ast (~> 2.3)
     pg (0.21.0)
-    poltergeist (1.16.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     public_suffix (3.0.1)
     puma (3.11.0)
@@ -223,6 +227,7 @@ GEM
     redis (3.2.2)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
+    regexp_parser (1.2.0)
     rotp (3.3.0)
     rqrcode (0.10.1)
       chunky_png (~> 1.0)
@@ -234,6 +239,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    rubyzip (1.2.2)
     rufus-scheduler (3.4.2)
       et-orbi (~> 1.0)
     sass (3.5.3)
@@ -247,6 +253,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.141.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2, >= 1.2.2)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)
       shoulda-matchers (>= 1.4.1, < 3.0)
@@ -319,8 +328,8 @@ GEM
     websocket-extensions (0.1.3)
     whenever (0.10.0)
       chronic (>= 0.6.3)
-    xpath (2.1.0)
-      nokogiri (~> 1.3)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -331,6 +340,8 @@ DEPENDENCIES
   capistrano
   capistrano-rails
   capistrano-rails-console
+  capybara
+  chromedriver-helper
   codeclimate-test-reporter
   coffee-rails (~> 4.2)
   daemon_controller
@@ -349,7 +360,6 @@ DEPENDENCIES
   mocha
   net-ssh (= 3.0.1)
   pg (~> 0.18)
-  poltergeist
   puma (~> 3.4)
   rails (= 5.1.4)
   rails-assets-clipboard!
@@ -360,6 +370,7 @@ DEPENDENCIES
   rqrcode (~> 0.10)
   rubocop
   sass-rails (~> 5.0)
+  selenium-webdriver
   shoulda
   sidekiq (~> 4.0)
   sidekiq-cron (~> 0.4.0)
@@ -377,4 +388,4 @@ DEPENDENCIES
   whenever (~> 0.9)
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/test/integration/manage_users_test.rb
+++ b/test/integration/manage_users_test.rb
@@ -26,7 +26,9 @@ class ManageUsersTest < IntegrationTest
     click_link "Users"
 
     within "#user_#{user.id}" do
-      click_link "Remove"
+      accept_confirm do
+        click_link "Remove"
+      end
     end
 
     # We need to give jquery a bit of time to let the record fadeout and

--- a/test/integration/new_server_test.rb
+++ b/test/integration/new_server_test.rb
@@ -14,10 +14,7 @@ class NewServerTest < IntegrationTest
     interact_with_hidden_elements do
       fill_in "server[name]", with: "Example server"
       fill_in "server[ip]", with: "127.0.0.1"
-      assert_difference "Server.count" do
-        find("input[type=submit]").trigger("click")
-        wait_for_ajax
-      end
+      click_button "Add server"
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,6 @@ require 'minitest/mock'
 require "mocha/mini_test"
 require "minitest/reporters"
 require "database_cleaner"
-require 'capybara/poltergeist'
 
 Sidekiq::Testing.fake!
 
@@ -18,6 +17,18 @@ Minitest::Reporters.use!([Minitest::Reporters::DefaultReporter.new(reporter_opti
 
 DatabaseCleaner.clean_with :truncation
 DatabaseCleaner.strategy = :truncation
+
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless window-size=1024,768 no-sandbox) }
+  )
+
+  Capybara::Selenium::Driver.new app,
+    browser: :chrome,
+    desired_capabilities: capabilities
+end
+
+Capybara.javascript_driver = :headless_chrome
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in test/support/ and its subdirectories.
@@ -45,11 +56,6 @@ class ActionDispatch::IntegrationTest
   include Capybara::DSL
 
   self.use_transactional_tests = false
-
-  Capybara.register_driver :poltergeist do |app|
-    Capybara::Poltergeist::Driver.new(app, js_errors: true)
-  end
-  Capybara.javascript_driver = :poltergeist
 
   teardown do
     DatabaseCleaner.clean

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,11 @@ Minitest::Reporters.use!([Minitest::Reporters::DefaultReporter.new(reporter_opti
 DatabaseCleaner.clean_with :truncation
 DatabaseCleaner.strategy = :truncation
 
+Capybara.register_server :puma do |app, port, host|
+  require 'rack/handler/puma'
+  Rack::Handler::Puma.run(app, Host: host, Port: port, Threads: "0:1")
+end
+
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w(headless window-size=1024,768 no-sandbox) }


### PR DESCRIPTION
While kicking off some more development today, I noticed that Poltergeist is not supported/maintained anymore. 

This PR converts the integration+browsers tests to a setup that is already aligned with new Rails 5.2 capabilities:
- Use selenium-webdriver and chromedriver-helper gems.
- Set headless chrome settings in `test_helper.rb`
- Set Puma to be used as Capybara server with single thread mode configured