### PR TITLE
Initial API applications / Integrations management

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 V 0.5.0 * TBD
 * Updated rails to 5.1 and ruby to 2.4.2 (jvanbaarsen)
 * Fix typo bug in production.rb preventing the app to start (jvanbaarsen)
+* Add Docker Compose setup for local development (michiels)
 
 V 0.4.0 * 2017-12-01
 * When no Dokku installed, make sure version check is not breaking. Fixes #229 (jvanbaarsen)

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,4 @@ ADD Gemfile /myapp/Gemfile
 ADD Gemfile.lock /myapp/Gemfile.lock
 RUN bundle install
 ADD . /myapp
-ENV APP_HOST=127.0.0.1
 CMD bundle exec rails s

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM ruby:2.4.1
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev
-RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
-RUN tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2
-RUN mv phantomjs-2.1.1-linux-x86_64 /usr/local/share
-RUN ln -sf /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin
+RUN wget -q https://github.com/ariya/phantomjs/releases/download/2.1.3/phantomjs
+RUN mv phantomjs /usr/local/bin
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash
 RUN mkdir /myapp
 WORKDIR /myapp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM ruby:2.4.1
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev
+RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
+RUN tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2
+RUN mv phantomjs-2.1.1-linux-x86_64 /usr/local/share
+RUN ln -sf /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash
 RUN mkdir /myapp
 WORKDIR /myapp
@@ -8,6 +12,5 @@ ADD Gemfile.lock /myapp/Gemfile.lock
 RUN bundle install
 ADD . /myapp
 ENV APP_HOST=127.0.0.1
-RUN bundle exec rake assets:precompile
 CMD bundle exec rails s
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,4 @@ ADD . /myapp
 ENV APP_HOST=127.0.0.1
 RUN bundle exec rake assets:precompile
 CMD bundle exec rails s
+EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,21 @@
-FROM ruby:2.4.1
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev
-RUN wget -q https://github.com/ariya/phantomjs/releases/download/2.1.3/phantomjs
-RUN mv phantomjs /usr/local/bin
-RUN curl -o- -L https://yarnpkg.com/install.sh | bash
-RUN mkdir /myapp
-WORKDIR /myapp
-ADD Gemfile /myapp/Gemfile
-ADD Gemfile.lock /myapp/Gemfile.lock
+FROM ruby:2.4.2
+
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev apt-transport-https unzip
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get update && apt-get install -y yarn nodejs
+
+RUN apt-get install -y libappindicator3-1 fonts-liberation libasound2 libnspr4 libnss3 libxss1 xdg-utils lsb-release
+RUN curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN dpkg -i google-chrome.deb
+RUN sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
+RUN rm google-chrome.deb
+
+RUN mkdir /app
+WORKDIR /app
+ADD Gemfile /app/Gemfile
+ADD Gemfile.lock /app/Gemfile.lock
 RUN bundle install
-ADD . /myapp
+ADD . /app
 CMD bundle exec rails s

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:2.4.1
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash
+RUN mkdir /myapp
+WORKDIR /myapp
+ADD Gemfile /myapp/Gemfile
+ADD Gemfile.lock /myapp/Gemfile.lock
+RUN bundle install
+ADD . /myapp
+ENV APP_HOST=127.0.0.1
+RUN bundle exec rake assets:precompile
+CMD bundle exec rails s

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,3 @@ RUN bundle install
 ADD . /myapp
 ENV APP_HOST=127.0.0.1
 CMD bundle exec rails s
-EXPOSE 3000

--- a/Gemfile
+++ b/Gemfile
@@ -42,11 +42,11 @@ end
 
 group :development, :test do
   gem "awesome_print"
+  gem "capybara"
+  gem "chromedriver-helper"
   gem "dotenv-rails", "2.2.1"
   gem "rubocop"
   gem "selenium-webdriver"
-  gem "capybara"
-  gem "chromedriver-helper"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ group :development, :test do
   gem "awesome_print"
   gem "dotenv-rails", "2.2.1"
   gem "rubocop"
+  gem "selenium-webdriver"
+  gem "capybara"
+  gem "chromedriver-helper"
 end
 
 group :test do
@@ -52,7 +55,6 @@ group :test do
   gem "launchy"
   gem "minitest-reporters"
   gem "mocha"
-  gem "poltergeist"
   gem "shoulda"
   gem "timecop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
     ansi (1.5.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.3.0)
     awesome_print (1.8.0)
@@ -67,16 +69,21 @@ GEM
     capistrano-rails-console (2.2.1)
       capistrano (>= 3.5.0, < 4.0.0)
       sshkit-interactive (~> 0.2.0)
-    capybara (2.16.1)
+    capybara (3.10.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (~> 2.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (2.1.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     chronic (0.10.2)
     chunky_png (1.3.8)
-    cliver (0.3.2)
     codeclimate-test-reporter (1.0.8)
       simplecov (<= 0.13)
     coffee-rails (4.2.2)
@@ -113,6 +120,7 @@ GEM
       activesupport (>= 3.0)
       loofah (>= 2.0)
       nokogiri (>= 1.6)
+    io-like (0.3.0)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -174,10 +182,6 @@ GEM
     parser (2.4.0.2)
       ast (~> 2.3)
     pg (0.21.0)
-    poltergeist (1.16.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     public_suffix (3.0.1)
     puma (3.11.0)
@@ -223,6 +227,7 @@ GEM
     redis (3.2.2)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
+    regexp_parser (1.2.0)
     rotp (3.3.0)
     rqrcode (0.10.1)
       chunky_png (~> 1.0)
@@ -234,6 +239,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    rubyzip (1.2.2)
     rufus-scheduler (3.4.2)
       et-orbi (~> 1.0)
     sass (3.5.3)
@@ -247,6 +253,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.141.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2, >= 1.2.2)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)
       shoulda-matchers (>= 1.4.1, < 3.0)
@@ -319,8 +328,8 @@ GEM
     websocket-extensions (0.1.3)
     whenever (0.10.0)
       chronic (>= 0.6.3)
-    xpath (2.1.0)
-      nokogiri (~> 1.3)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -331,6 +340,8 @@ DEPENDENCIES
   capistrano
   capistrano-rails
   capistrano-rails-console
+  capybara
+  chromedriver-helper
   codeclimate-test-reporter
   coffee-rails (~> 4.2)
   daemon_controller
@@ -349,7 +360,6 @@ DEPENDENCIES
   mocha
   net-ssh (= 3.0.1)
   pg (~> 0.18)
-  poltergeist
   puma (~> 3.4)
   rails (= 5.1.4)
   rails-assets-clipboard!
@@ -360,6 +370,7 @@ DEPENDENCIES
   rqrcode (~> 0.10)
   rubocop
   sass-rails (~> 5.0)
+  selenium-webdriver
   shoulda
   sidekiq (~> 4.0)
   sidekiq-cron (~> 0.4.0)
@@ -377,4 +388,4 @@ DEPENDENCIES
   whenever (~> 0.9)
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/README.md
+++ b/README.md
@@ -14,10 +14,63 @@ For installation instructions, please see our [install manual][install]
 
 ## Set up your Dev environment
 
-1. Make sure you have Postgresql installed
-1. Clone this repo
-1. Run `bin/setup`
-1. Start the app with `foreman start`
+1. Make sure you have PostgreSQL and Redis installed
+2. Clone this repo
+3. Run `bin/setup`
+4. Start the app with `foreman start`
+
+## Set up your Dev environment using Docker
+
+You can also set up your local development environment without having to install
+any outside dependencies. For this, use the Docker Compose configuration that's
+available in this repository. This configuration automatically mounts your
+local code inside a container, so that you can make changes and commit your
+code as if you were running a local development server without Docker.
+
+First, install Docker for your workstation: https://www.docker.com/community-edition
+
+Then, use `docker-compose` commands to set up a local environment using Docker
+and run the development server:
+
+```
+$ docker-compose run web rails db:create
+$ docker-compose run web rails db:schema:load
+```
+
+Optionally, run the seeds to already have an initial user and if you don't
+need to test the onboarding:
+
+```
+$ docker-compose run web rake db:seed
+```
+
+Then, start the local development server:
+
+```
+$ docker-compose run web -p 3000:3000 rails s
+```
+
+You can start Sidekiq for background jobs via:
+
+```
+$ docker-compose run sidekiq -q default -q mailers -q health_checks
+```
+
+### Running tests
+
+You can run tests via:
+
+```
+docker-compose run web rails test
+```
+
+### Running DB migrations
+
+You can run database migrations via:
+
+```
+docker-compose run web rails db:migrate
+```
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,18 @@ You can start Sidekiq for background jobs via:
 $ docker-compose run sidekiq -q default -q mailers -q health_checks
 ```
 
+Or alternatively, to start everything in one go:
+
+```
+$ docker-compose up
+```
+
 ### Running tests
 
 You can run tests via:
 
 ```
-docker-compose run web rails test
+$ docker-compose run web rails test
 ```
 
 ### Running DB migrations

--- a/README.md
+++ b/README.md
@@ -29,34 +29,25 @@ code as if you were running a local development server without Docker.
 
 First, install Docker for your workstation: https://www.docker.com/community-edition
 
-Then, use `docker-compose` commands to set up a local environment using Docker
-and run the development server:
+Then, use `docker-compose` commands to set up a local environment:
 
 ```
-$ docker-compose run web rails db:create
-$ docker-compose run web rails db:schema:load
+$ docker-compose run web /bin/bash
+# rails db:create
+# rails db:schema:load
 ```
 
 Optionally, run the seeds to already have an initial user and if you don't
 need to test the onboarding:
 
 ```
-$ docker-compose run web rake db:seed
+# rails db:seed
 ```
+
+Open up another tab in your terminal, or exit the shell session inside the
+container again via Control-D.
 
 Then, start the local development server:
-
-```
-$ docker-compose run web -p 3000:3000 rails s
-```
-
-You can start Sidekiq for background jobs via:
-
-```
-$ docker-compose run sidekiq -q default -q mailers -q health_checks
-```
-
-Or alternatively, to start everything in one go:
 
 ```
 $ docker-compose up
@@ -67,7 +58,8 @@ $ docker-compose up
 You can run tests via:
 
 ```
-$ docker-compose run web rails test
+$ docker-compose run web /bin/bash
+# rails test
 ```
 
 ### Running DB migrations
@@ -75,7 +67,9 @@ $ docker-compose run web rails test
 You can run database migrations via:
 
 ```
-$ docker-compose run web rails db:migrate
+$ docker-compose run web /bin/bash
+# rails g migration AddAColumnToATable column:string
+# rails db:migrate
 ```
 
 ### Modifying Gemfile

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Then, start the local development server:
 $ docker-compose up
 ```
 
+To stop your local development environment again where you're finished working:
+
+```
+$ docker-compose down
+```
+
 ### Running tests
 
 You can run tests via:

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ $ docker-compose run --rm web /bin/bash
 
 ### Modifying Gemfile
 
-After you've made a change to the Gemfile, you need to rebuild the local
-image to install/remove/update the gems:
+After you've made a change to the Gemfile, you need to rebuild your local Docker
+container image via docker-compose and restart the local development server:
 
 ```
 $ docker-compose down

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ First, install Docker for your workstation: https://www.docker.com/community-edi
 Then, use `docker-compose` commands to set up a local environment:
 
 ```
-$ docker-compose run web /bin/bash
+$ docker-compose run --rm web /bin/bash
 # rails db:create
 # rails db:schema:load
 ```
@@ -58,7 +58,7 @@ $ docker-compose up
 You can run tests via:
 
 ```
-$ docker-compose run web /bin/bash
+$ docker-compose run --rm web /bin/bash
 # rails test
 ```
 
@@ -67,7 +67,7 @@ $ docker-compose run web /bin/bash
 You can run database migrations via:
 
 ```
-$ docker-compose run web /bin/bash
+$ docker-compose run --rm web /bin/bash
 # rails g migration AddAColumnToATable column:string
 # rails db:migrate
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,18 @@ $ docker-compose run web rails test
 You can run database migrations via:
 
 ```
-docker-compose run web rails db:migrate
+$ docker-compose run web rails db:migrate
+```
+
+### Modifying Gemfile
+
+After you've made a change to the Gemfile, you need to rebuild the local
+image to install/remove/update the gems:
+
+```
+$ docker-compose down
+$ docker-compose build
+$ docker-compose up
 ```
 
 ## Support

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -1,0 +1,4 @@
+class IntegrationsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -1,4 +1,6 @@
 class IntegrationsController < ApplicationController
   def index
+    @integrations = Integration.all
+    @integration = Integration.new
   end
 end

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -14,6 +14,10 @@ class IntegrationsController < ApplicationController
     @integration.destroy
   end
 
+  def reveal
+    @integration = Integration.find(params[:id])
+  end
+
   private
 
   def integration_params

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -3,4 +3,20 @@ class IntegrationsController < ApplicationController
     @integrations = Integration.all
     @integration = Integration.new
   end
+
+  def create
+    @integration = Integration.new(integration_params)
+    @integration.save
+  end
+
+  def destroy
+    @integration = Integration.find(params[:id])
+    @integration.destroy
+  end
+
+  private
+
+  def integration_params
+    params.require(:integration).permit(:name)
+  end
 end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -1,0 +1,2 @@
+class Integration < ApplicationRecord
+end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -1,2 +1,4 @@
 class Integration < ApplicationRecord
+  validates :name, presence: true
+  has_secure_token :access_token
 end

--- a/app/views/application/_navigation.html.erb
+++ b/app/views/application/_navigation.html.erb
@@ -7,7 +7,7 @@
       <%= link_to "Servers", root_path, class: "nav-item is-tab #{"is-active" if @active_menu.blank?}" %>
       <%= link_to "Users", users_path, class: "nav-item is-tab #{"is-active" if @active_menu == "users"}" %>
       <%= link_to "Settings", edit_settings_path, class: "nav-item is-tab #{"is-active" if @active_menu == "settings"}" %>
-      <%= link_to "Help", help_path, class: "nav-item is-tab #{"is-active" if @active_menu == "help"}" %>
+      <%= link_to "Integrations", integrations_path, class: "nav-item is-tab #{"is-active" if @active_menu == "integrations"}" %>
     </div>
 
     <!-- Hamburger menu (on mobile) -->

--- a/app/views/integrations/_form.html.erb
+++ b/app/views/integrations/_form.html.erb
@@ -6,7 +6,7 @@
         class: "input", data: { error: @integration.errors[:name].first } %>
     </div>
     <p class="control">
-    <%= f.submit "Add new integration", class: "button is-primary" %>
+    <%= f.submit "Add new application", class: "button is-primary" %>
     </p>
   <% end %>
 </div>

--- a/app/views/integrations/_form.html.erb
+++ b/app/views/integrations/_form.html.erb
@@ -1,0 +1,12 @@
+<div class="box">
+  <h1 class="subtitle">Add a application</h1>
+  <%= form_for @integration, remote: true do |f| %>
+    <div class="control">
+      <%= f.text_field :name, placeholder: "My API application", hide_label: true,
+        class: "input", data: { error: @integration.errors[:name].first } %>
+    </div>
+    <p class="control">
+    <%= f.submit "Add new integration", class: "button is-primary" %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/integrations/_integration.html.erb
+++ b/app/views/integrations/_integration.html.erb
@@ -1,0 +1,7 @@
+<%= content_tag :tr, id: dom_id(integration), class: "integration" do %>
+  <td><%= integration.name %></td>
+  <td><%= integration.access_token %></td>
+  <td class="actions is-link is-danger">
+    <%= link_to "Remove", integration_path(integration), remote: true, method: :delete, class: "is-danger", data: { confirm: "Are you sure you want to fully remove this integration?" } %>
+  </td>
+<% end %>

--- a/app/views/integrations/_integration.html.erb
+++ b/app/views/integrations/_integration.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag :tr, id: dom_id(integration), class: "integration" do %>
-  <td><%= integration.name %></td>
-  <td><%= integration.access_token %></td>
+  <td width="20%"><%= integration.name %></td>
+  <td><%= link_to "Click to reveal", reveal_integration_path(integration), remote: true, data: { role: "click-to-reveal" } %></td>
   <td class="actions is-link is-danger">
     <%= link_to "Remove", integration_path(integration), remote: true, method: :delete, class: "is-danger", data: { confirm: "Are you sure you want to fully remove this integration?" } %>
   </td>

--- a/app/views/integrations/create.js.erb
+++ b/app/views/integrations/create.js.erb
@@ -1,0 +1,10 @@
+<% if @integration.persisted? %>
+  $("[data-role=empty-state]").hide()
+  $('body').find('.integrations tbody').append("<%= j render @integration %>")
+  $('body').find("[data-role~=form] form").trigger("reset")
+  $('body').find("[data-role~=empty-table]").addClass("is-hidden")
+<% else %>
+  $('body').find("[data-role~=form]").html("<%= j render "form" %>");
+<% end %>
+new FormErrorHandler().reset()
+new FormErrorHandler().execute()

--- a/app/views/integrations/destroy.js.erb
+++ b/app/views/integrations/destroy.js.erb
@@ -1,0 +1,3 @@
+<% if @integration.destroyed? %>
+$("tr#<%= dom_id(@integration) %>").remove()
+<% end %>

--- a/app/views/integrations/index.html.erb
+++ b/app/views/integrations/index.html.erb
@@ -1,0 +1,20 @@
+<% @active_menu = "integrations" %>
+
+<h1 class="title">Applications</h1>
+<div class="columns">
+  <div class="column is-8">
+    <table class="table is-striped users">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Access Token</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+      </tbody>
+    </table>
+  </div>
+  <div data-role="form" class="column is-4">
+  </div>
+</div>

--- a/app/views/integrations/index.html.erb
+++ b/app/views/integrations/index.html.erb
@@ -3,7 +3,7 @@
 <h1 class="title">Applications</h1>
 <div class="columns">
   <div class="column is-8">
-    <table class="table is-striped users">
+    <table class="table is-striped integrations">
       <thead>
         <tr>
           <th>Name</th>
@@ -12,9 +12,15 @@
         </tr>
       </thead>
       <tbody>
+        <%= render @integrations %>
       </tbody>
     </table>
+
+    <% if @integrations.blank? %>
+      <p data-role="empty-state">You don't have any application access tokens yet. To obtain an access token to interact with your Intercity instance API, please add an application first.</p>
+    <% end %>
   </div>
   <div data-role="form" class="column is-4">
+    <%= render "form" %>
   </div>
 </div>

--- a/app/views/integrations/reveal.js.erb
+++ b/app/views/integrations/reveal.js.erb
@@ -1,0 +1,1 @@
+$("tr#<%= dom_id(@integration) %> [data-role=click-to-reveal]").replaceWith("<code><%= j @integration.access_token %></code>")

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,10 +2,11 @@ development: &default
   adapter: postgresql
   database: intercity-next_development
   encoding: utf8
-  host: localhost
+  host: <%= ENV["DB_HOST"] || "localhost" %>
   min_messages: warning
   pool: 2
   timeout: 5000
+  username: <%= ENV["DB_USER"] || "root" %>
 
 test:
   <<: *default

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,10 +1,13 @@
 require 'securerandom'
 
-token = $redis.get("SECRET_KEY_BASE")
-if token.nil?
-  token = SecureRandom.hex(64)
-  $redis.set("SECRET_KEY_BASE", token)
-end
+token = SecureRandom.hex(64)
 
-Rails.application.config.secret_token = token
-Rails.application.config.secret_key_base = token
+begin
+  token = Redis.current.get("SECRET_KEY_BASE")
+  if token.nil?
+    Redis.current.set("SECRET_KEY_BASE", token)
+  end
+rescue
+  Rails.application.config.secret_token = token
+  Rails.application.config.secret_key_base = token
+end

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -3,11 +3,15 @@ require 'securerandom'
 token = SecureRandom.hex(64)
 
 begin
-  token = Redis.current.get("SECRET_KEY_BASE")
-  if token.nil?
+  current_token = Redis.current.get("SECRET_KEY_BASE")
+  if current_token.blank?
     Redis.current.set("SECRET_KEY_BASE", token)
+  else
+    token = current_token
   end
-rescue
-  Rails.application.config.secret_token = token
-  Rails.application.config.secret_key_base = token
+rescue => e
+  puts e.inspect
 end
+
+Rails.application.config.secret_token = token
+Rails.application.config.secret_key_base = token

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ require 'sidekiq/cron/web'
 require "user_constraint"
 
 Rails.application.routes.draw do
-
   mount Sidekiq::Web => "/sidekiq", constraints: UserConstraint.new
   root to: "servers#index"
 
@@ -56,6 +55,8 @@ Rails.application.routes.draw do
   resource :settings, only: [:edit, :update] do
     root to: "settings#edit"
   end
+
+  resources :integrations
 
   # Help
   get 'help'                  => 'help#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,11 @@ Rails.application.routes.draw do
     root to: "settings#edit"
   end
 
-  resources :integrations
+  resources :integrations do
+    member do
+      get :reveal
+    end
+  end
 
   # Help
   get 'help'                  => 'help#index'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,6 @@
 ---
 :concurrency: 5
 :pidfile: tmp/sidekiq.pid
-:logfile: log/sidekiq.log
 production:
   :concurrency: 20
 :queues:

--- a/db/migrate/20181103210156_create_integrations.rb
+++ b/db/migrate/20181103210156_create_integrations.rb
@@ -1,0 +1,10 @@
+class CreateIntegrations < ActiveRecord::Migration[5.1]
+  def change
+    create_table :integrations do |t|
+      t.string :name
+      t.string :access_token
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,137 +10,144 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161123123228) do
+ActiveRecord::Schema.define(version: 20181103210156) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "active_services", force: :cascade do |t|
-    t.integer  "service_id"
-    t.integer  "server_id"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "status",     default: 0
-    t.index ["server_id"], name: "index_active_services_on_server_id", using: :btree
-    t.index ["service_id"], name: "index_active_services_on_service_id", using: :btree
+    t.integer "service_id"
+    t.integer "server_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "status", default: 0
+    t.index ["server_id"], name: "index_active_services_on_server_id"
+    t.index ["service_id"], name: "index_active_services_on_service_id"
   end
 
   create_table "apps", force: :cascade do |t|
-    t.integer  "server_id"
-    t.string   "name"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.boolean  "busy",            default: false
-    t.boolean  "backups_enabled", default: false
-    t.text     "ssl_key"
-    t.text     "ssl_cert"
-    t.boolean  "ssl_enabled",     default: false
-    t.index ["server_id"], name: "index_apps_on_server_id", using: :btree
+    t.integer "server_id"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "busy", default: false
+    t.boolean "backups_enabled", default: false
+    t.text "ssl_key"
+    t.text "ssl_cert"
+    t.boolean "ssl_enabled", default: false
+    t.index ["server_id"], name: "index_apps_on_server_id"
   end
 
   create_table "backups", force: :cascade do |t|
-    t.string   "filename"
-    t.integer  "service_id"
-    t.integer  "app_id"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.boolean  "running",     default: false
-    t.integer  "backup_type", default: 0
-    t.boolean  "rotated",     default: false
-    t.index ["app_id"], name: "index_backups_on_app_id", using: :btree
-    t.index ["service_id"], name: "index_backups_on_service_id", using: :btree
+    t.string "filename"
+    t.integer "service_id"
+    t.integer "app_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "running", default: false
+    t.integer "backup_type", default: 0
+    t.boolean "rotated", default: false
+    t.index ["app_id"], name: "index_backups_on_app_id"
+    t.index ["service_id"], name: "index_backups_on_service_id"
   end
 
   create_table "deploy_keys", force: :cascade do |t|
-    t.string   "name"
-    t.text     "key"
-    t.integer  "server_id"
+    t.string "name"
+    t.text "key"
+    t.integer "server_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["server_id"], name: "index_deploy_keys_on_server_id", using: :btree
+    t.index ["server_id"], name: "index_deploy_keys_on_server_id"
   end
 
   create_table "domains", force: :cascade do |t|
     t.integer "app_id"
-    t.string  "name"
-    t.index ["app_id"], name: "index_domains_on_app_id", using: :btree
+    t.string "name"
+    t.index ["app_id"], name: "index_domains_on_app_id"
   end
 
   create_table "env_vars", force: :cascade do |t|
-    t.string   "key"
-    t.string   "value"
-    t.integer  "app_id"
+    t.string "key"
+    t.string "value"
+    t.integer "app_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["app_id"], name: "index_env_vars_on_app_id", using: :btree
+    t.index ["app_id"], name: "index_env_vars_on_app_id"
+  end
+
+  create_table "integrations", force: :cascade do |t|
+    t.string "name"
+    t.string "access_token"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "linked_services", force: :cascade do |t|
-    t.integer  "app_id"
-    t.integer  "service_id"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "status",     default: 0
-    t.index ["app_id"], name: "index_linked_services_on_app_id", using: :btree
-    t.index ["service_id"], name: "index_linked_services_on_service_id", using: :btree
+    t.integer "app_id"
+    t.integer "service_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "status", default: 0
+    t.index ["app_id"], name: "index_linked_services_on_app_id"
+    t.index ["service_id"], name: "index_linked_services_on_service_id"
   end
 
   create_table "servers", force: :cascade do |t|
-    t.string   "name"
-    t.string   "ip"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-    t.text     "rsa_key_public"
-    t.text     "rsa_key_private"
-    t.boolean  "connected",       default: false
-    t.integer  "status",          default: 0
-    t.string   "dokku_version"
-    t.boolean  "updating",        default: false
-    t.integer  "install_step",    default: 1
-    t.boolean  "swap_enabled",    default: false
-    t.integer  "total_ram"
-    t.integer  "total_disk"
-    t.integer  "total_cpu"
-    t.string   "username",        default: "root"
+    t.string "name"
+    t.string "ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "rsa_key_public"
+    t.text "rsa_key_private"
+    t.boolean "connected", default: false
+    t.integer "status", default: 0
+    t.string "dokku_version"
+    t.boolean "updating", default: false
+    t.integer "install_step", default: 1
+    t.boolean "swap_enabled", default: false
+    t.integer "total_ram"
+    t.integer "total_disk"
+    t.integer "total_cpu"
+    t.string "username", default: "root"
   end
 
   create_table "services", force: :cascade do |t|
-    t.string   "name"
-    t.boolean  "active",     default: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.json     "commands"
+    t.string "name"
+    t.boolean "active", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.json "commands"
   end
 
   create_table "settings", force: :cascade do |t|
-    t.string   "from_email"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
-    t.boolean  "enable_smtp",   default: false
-    t.string   "smtp_address"
-    t.integer  "smtp_port"
-    t.string   "smtp_username"
-    t.string   "smtp_password"
-    t.string   "smtp_domain"
+    t.string "from_email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "enable_smtp", default: false
+    t.string "smtp_address"
+    t.integer "smtp_port"
+    t.string "smtp_username"
+    t.string "smtp_password"
+    t.string "smtp_domain"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                                           null: false
-    t.string   "crypted_password"
-    t.string   "salt"
+    t.string "email", null: false
+    t.string "crypted_password"
+    t.string "salt"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "activation_token"
-    t.string   "totp_secret"
-    t.boolean  "two_factor_auth_enabled",         default: false
-    t.string   "remember_me_token"
+    t.string "activation_token"
+    t.string "totp_secret"
+    t.boolean "two_factor_auth_enabled", default: false
+    t.string "remember_me_token"
     t.datetime "remember_me_token_expires_at"
-    t.string   "reset_password_token"
+    t.string "reset_password_token"
     t.datetime "reset_password_token_expires_at"
-    t.index ["activation_token"], name: "index_users_on_activation_token", using: :btree
-    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["remember_me_token"], name: "index_users_on_remember_me_token", using: :btree
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", using: :btree
+    t.index ["activation_token"], name: "index_users_on_activation_token"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
   add_foreign_key "active_services", "servers"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  db:
+    image: postgres
+  redis:
+    image: redis
+  web:
+    build: .
+    command: bundle exec rails s
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+      - redis
+    environment:
+      - RAILS_ENV=production
+      - DATABASE_URL=postgresql://postgres:@db:5432/intercity
+      - RAILS_SERVE_STATIC_FILES=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,8 @@ services:
       - redis
     environment:
       - RAILS_ENV=development
-      - DATABASE_URL=postgresql://postgres:@db:5432/intercity
+      - DB_HOST=db
+      - DB_USER=postgres
       - SECRET_KEY_BASE=a
       - RAILS_SERVE_STATIC_FILES=true
       - REDIS_URL=redis://redis:6379
@@ -31,7 +32,8 @@ services:
       - .:/myapp
     environment:
       - RAILS_ENV=development
-      - DATABASE_URL=postgresql://postgres:@db:5432/intercity
+      - DB_HOST=db
+      - DB_USER=postgres
       - REDIS_URL=redis://redis:6379
       - SECRET_KEY_BASE=a
       - RAILS_SERVE_STATIC_FILES=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,37 +10,27 @@ services:
       - redis-data:/data
   web:
     build: .
+    image: intercitynext_web
     volumes:
-      - .:/myapp
+      - .:/app
     command: bundle exec rails s
     ports:
-      - "3000:3000"
+      - "3000"
     depends_on:
       - db
       - redis
-    environment:
-      - RAILS_ENV=development
-      - DB_HOST=db
-      - DB_USER=postgres
+    environment: &ENV
+      - DATABASE_URL=postgres://postgres@db/
       - SECRET_KEY_BASE=a
       - RAILS_SERVE_STATIC_FILES=true
-      - REDIS_URL=redis://redis:6379
-      - HOSTNAME=intercity.example.com
       - RAILS_LOG_TO_STDOUT=true
+      - REDIS_URL=redis://redis:6379
   sidekiq:
     image: intercitynext_web
     command: bundle exec sidekiq -q default -q mailers -q health_checks
     volumes:
-      - .:/myapp
-    environment:
-      - RAILS_ENV=development
-      - DB_HOST=db
-      - DB_USER=postgres
-      - REDIS_URL=redis://redis:6379
-      - SECRET_KEY_BASE=a
-      - RAILS_SERVE_STATIC_FILES=true
-      - HOSTNAME=intercity.example.com
-      - RAILS_LOG_TO_STDOUT=true
+      - .:/app
+    environment: *ENV
     depends_on:
       - db
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,14 @@ services:
       - redis-data:/data
   web:
     build: .
+    volumes:
+      - .:/myapp
     command: bundle exec rails s
     depends_on:
       - db
       - redis
     environment:
-      - RAILS_ENV=production
+      - RAILS_ENV=development
       - DATABASE_URL=postgresql://postgres:@db:5432/intercity
       - SECRET_KEY_BASE=a
       - RAILS_SERVE_STATIC_FILES=true
@@ -25,8 +27,10 @@ services:
   sidekiq:
     image: intercitynext_web
     command: bundle exec sidekiq -q default -q mailers -q health_checks
+    volumes:
+      - .:/myapp
     environment:
-      - RAILS_ENV=production
+      - RAILS_ENV=development
       - DATABASE_URL=postgresql://postgres:@db:5432/intercity
       - REDIS_URL=redis://redis:6379
       - SECRET_KEY_BASE=a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,40 @@ version: '3'
 services:
   db:
     image: postgres
+    volumes:
+      - pg-data:/var/lib/postgresql/data
   redis:
     image: redis
+    volumes:
+      - redis-data:/data
   web:
     build: .
     command: bundle exec rails s
-    ports:
-      - "3000:3000"
     depends_on:
       - db
       - redis
     environment:
       - RAILS_ENV=production
       - DATABASE_URL=postgresql://postgres:@db:5432/intercity
+      - SECRET_KEY_BASE=a
       - RAILS_SERVE_STATIC_FILES=true
+      - REDIS_URL=redis://redis:6379
+      - HOSTNAME=intercity.example.com
+      - RAILS_LOG_TO_STDOUT=true
+  sidekiq:
+    image: intercitynext_web
+    command: bundle exec sidekiq -q default -q mailers -q health_checks
+    environment:
+      - RAILS_ENV=production
+      - DATABASE_URL=postgresql://postgres:@db:5432/intercity
+      - REDIS_URL=redis://redis:6379
+      - SECRET_KEY_BASE=a
+      - RAILS_SERVE_STATIC_FILES=true
+      - HOSTNAME=intercity.example.com
+      - RAILS_LOG_TO_STDOUT=true
+    depends_on:
+      - db
+      - redis
+volumes:
+  pg-data:
+  redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     volumes:
       - .:/myapp
     command: bundle exec rails s
+    ports:
+      - "3000:3000"
     depends_on:
       - db
       - redis

--- a/test/controllers/integrations_controller_test.rb
+++ b/test/controllers/integrations_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class IntegrationsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get integrations_index_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/integrations.yml
+++ b/test/fixtures/integrations.yml
@@ -1,0 +1,3 @@
+api_application:
+  name: API Application
+  access_token: abcdefg

--- a/test/integration/app_overview_test.rb
+++ b/test/integration/app_overview_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class AppOverviewTest < IntegrationTest
+class AppOverviewTest < ActionDispatch::IntegrationTest
   test "User should see a list of all the apps for a given server" do
     login_as users(:john)
     visit root_path

--- a/test/integration/create_new_app_test.rb
+++ b/test/integration/create_new_app_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CreateNewAppTest < IntegrationTest
+class CreateNewAppTest < ActionDispatch::IntegrationTest
   test "User should be able to create a new app on a given server" do
     login_as users(:john)
     visit root_path

--- a/test/integration/empty_state_test.rb
+++ b/test/integration/empty_state_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class EmptyStateTest < IntegrationTest
+class EmptyStateTest < ActionDispatch::IntegrationTest
   test "When there are no users in the system, you should see the onboarding page" do
     User.destroy_all
 

--- a/test/integration/integrations_test.rb
+++ b/test/integration/integrations_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class IntegrationsTest < ActionDispatch::IntegrationTest
+  test "User should be able to create an integration" do
+    use_javascript
+    login_as users(:john)
+
+    visit root_path
+    click_link "Integrations"
+    fill_in "integration[name]", with: "My API"
+    click_button "Add new integration"
+
+    within ".integrations" do
+      assert page.has_content? "My API"
+    end
+  end
+end

--- a/test/integration/integrations_test.rb
+++ b/test/integration/integrations_test.rb
@@ -14,4 +14,20 @@ class IntegrationsTest < ActionDispatch::IntegrationTest
       assert page.has_content? "My API"
     end
   end
+
+  test "User should be able to reveal an integration access token" do
+    use_javascript
+    login_as users(:john)
+
+    visit root_path
+    click_link "Integrations"
+
+    integration = integrations(:api_application)
+
+    within "tr#integration_#{integration.id}" do
+      click_on "Click to reveal"
+    end
+
+    assert page.has_content?(integration.access_token)
+  end
 end

--- a/test/integration/integrations_test.rb
+++ b/test/integration/integrations_test.rb
@@ -8,7 +8,7 @@ class IntegrationsTest < ActionDispatch::IntegrationTest
     visit root_path
     click_link "Integrations"
     fill_in "integration[name]", with: "My API"
-    click_button "Add new integration"
+    click_button "Add new application"
 
     within ".integrations" do
       assert page.has_content? "My API"

--- a/test/integration/manage_settings_test.rb
+++ b/test/integration/manage_settings_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ManageSettingsTest < IntegrationTest
+class ManageSettingsTest < ActionDispatch::IntegrationTest
   test "User should be able to alter the FROM_EMAIL on the settings page" do
     login_as users(:john)
 

--- a/test/integration/manage_users_test.rb
+++ b/test/integration/manage_users_test.rb
@@ -31,7 +31,7 @@ class ManageUsersTest < IntegrationTest
 
     # We need to give jquery a bit of time to let the record fadeout and
     # disappear
-    sleep 0.4
+    sleep 1
 
     refute page.has_content?("jane@example.com"), "Page should not have Jane anymore"
   end

--- a/test/integration/manage_users_test.rb
+++ b/test/integration/manage_users_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ManageUsersTest < IntegrationTest
+class ManageUsersTest < ActionDispatch::IntegrationTest
   test "I want to be able to add new users to the system" do
     use_javascript
 

--- a/test/integration/manage_users_test.rb
+++ b/test/integration/manage_users_test.rb
@@ -26,7 +26,9 @@ class ManageUsersTest < IntegrationTest
     click_link "Users"
 
     within "#user_#{user.id}" do
-      click_link "Remove"
+      accept_confirm do
+        click_link "Remove"
+      end
     end
 
     # We need to give jquery a bit of time to let the record fadeout and

--- a/test/integration/new_server_test.rb
+++ b/test/integration/new_server_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class NewServerTest < IntegrationTest
+class NewServerTest < ActionDispatch::IntegrationTest
   test "User should be able to create a new server" do
     use_javascript
 

--- a/test/integration/new_server_test.rb
+++ b/test/integration/new_server_test.rb
@@ -14,10 +14,7 @@ class NewServerTest < IntegrationTest
     interact_with_hidden_elements do
       fill_in "server[name]", with: "Example server"
       fill_in "server[ip]", with: "127.0.0.1"
-      assert_difference "Server.count" do
-        find("input[type=submit]").trigger("click")
-        wait_for_ajax
-      end
+      click_button "Add server"
     end
   end
 end

--- a/test/integration/swap_flow_test.rb
+++ b/test/integration/swap_flow_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class SwapFlowTest < IntegrationTest
+class SwapFlowTest < ActionDispatch::IntegrationTest
   test "A user should be able to enable swap on a server" do
     login_as users(:john)
     visit server_path(servers(:example))

--- a/test/integration/user_activation_test.rb
+++ b/test/integration/user_activation_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class UserActivationTest < IntegrationTest
+class UserActivationTest < ActionDispatch::IntegrationTest
   test "User activation should be successfull" do
     user = users(:jane)
     visit edit_user_activation_path(user.activation_token)

--- a/test/integration/user_login_test.rb
+++ b/test/integration/user_login_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class UserLoginTest < IntegrationTest
+class UserLoginTest < ActionDispatch::IntegrationTest
   test "User login should be successfull" do
     visit root_path
 

--- a/test/models/integration_test.rb
+++ b/test/models/integration_test.rb
@@ -1,0 +1,5 @@
+require 'test_helper'
+
+class IntegrationTest < ActiveSupport::TestCase
+  should validate_presence_of :name
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,6 @@ require 'minitest/mock'
 require "mocha/mini_test"
 require "minitest/reporters"
 require "database_cleaner"
-require 'capybara/poltergeist'
 
 Sidekiq::Testing.fake!
 
@@ -18,6 +17,18 @@ Minitest::Reporters.use!([Minitest::Reporters::DefaultReporter.new(reporter_opti
 
 DatabaseCleaner.clean_with :truncation
 DatabaseCleaner.strategy = :truncation
+
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless window-size=1024,768 no-sandbox) }
+  )
+
+  Capybara::Selenium::Driver.new app,
+    browser: :chrome,
+    desired_capabilities: capabilities
+end
+
+Capybara.javascript_driver = :headless_chrome
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in test/support/ and its subdirectories.
@@ -45,11 +56,6 @@ class ActionDispatch::IntegrationTest
   include Capybara::DSL
 
   self.use_transactional_tests = false
-
-  Capybara.register_driver :poltergeist do |app|
-    Capybara::Poltergeist::Driver.new(app, js_errors: true)
-  end
-  Capybara.javascript_driver = :poltergeist
 
   teardown do
     DatabaseCleaner.clean

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,11 @@ Minitest::Reporters.use!([Minitest::Reporters::DefaultReporter.new(reporter_opti
 DatabaseCleaner.clean_with :truncation
 DatabaseCleaner.strategy = :truncation
 
+Capybara.register_server :puma do |app, port, host|
+  require 'rack/handler/puma'
+  Rack::Handler::Puma.run(app, Host: host, Port: port, Threads: "0:1")
+end
+
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w(headless window-size=1024,768 no-sandbox) }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,9 +88,7 @@ class ActionDispatch::IntegrationTest
     yield
     Capybara.ignore_hidden_elements = true
   end
-end
 
-class IntegrationTest < ActionDispatch::IntegrationTest
   def login_as(user)
     visit login_path
     fill_in "Email", with: user.email


### PR DESCRIPTION
This PR contains a first attempt at a simple API applications / Integrations management panel that generates access tokens per application. With this basis, we can continue on allowing API access via the "access_token" that is generated per integration.

Please ignore the Docker stuff in this PR. This is pending the merge of #238 

Screenshot:

<img width="1045" alt="schermafbeelding 2018-11-03 om 22 48 33" src="https://user-images.githubusercontent.com/42268/47957658-9fa37180-dfba-11e8-9ba6-2fec3eb03d8b.png">
<img width="1045" alt="schermafbeelding 2018-11-03 om 22 48 37" src="https://user-images.githubusercontent.com/42268/47957659-9fa37180-dfba-11e8-92e2-d9d92e4bb96a.png">

Some notes:

- I chose to call it "Integration" in the database and model,  since calling it something like "Application" is already very ambiguous with the Rails app in general and our notion of "Apps" that live on the server.
- I think it's good to scope an integration to one or multiple specific apps. This way we prevent people from being able to modify the whole infrastructure managed by Intercity until we have more granular permission scoping. Will also add this to note to #244 