### PR TITLE
Bump standard Dokku version to 0.12.13

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ V 0.5.0 * TBD
 * Fix typo bug in production.rb preventing the app to start (jvanbaarsen)
 * Add Docker Compose setup for local development (michiels)
 * Make sure we run certain commands as sudo (jvanbaarsen)
+* Update standard Dokku version to 0.12.13
 
 V 0.4.0 * 2017-12-01
 * When no Dokku installed, make sure version check is not breaking. Fixes #229 (jvanbaarsen)

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -31,7 +31,7 @@ class Server < ApplicationRecord
   end
 
   def latest_dokku_version
-    "v0.10.5".freeze
+    "v0.12.13".freeze
   end
 
   def formatted_status


### PR DESCRIPTION
This PR bumps the Dokku version to 0.12.13.

Things to test:

Note: these were all tested via `root` account (not a sudo user)

- [x] Installing a server
- [x] Adding an application
- [x] Specifying ENV vars
- [x] Adding deploy keys
- [x] Installing services
- [x] Enabling swap
- [x] Managing SSL certificate
- [x] Manage domains