### PR TITLE
Revert database.yml change that added explicit DB HOST and DB_USER

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,11 +2,10 @@ development: &default
   adapter: postgresql
   database: intercity-next_development
   encoding: utf8
-  host: <%= ENV["DB_HOST"] || "localhost" %>
+  host: localhost
   min_messages: warning
   pool: 2
   timeout: 5000
-  username: <%= ENV["DB_USER"] || "root" %>
 
 test:
   <<: *default


### PR DESCRIPTION
This reverts a change made in `database.yml` in PR https://github.com/intercity/intercity-next/pull/238 where explicit DB_HOST and DB_USER ENV var reading was added. This breaks our Docker-based installer.