### PR TITLE
Don't apply ENV var changes right away and offer restart option

### DIFF
--- a/app/controllers/apps/restarts_controller.rb
+++ b/app/controllers/apps/restarts_controller.rb
@@ -1,0 +1,6 @@
+class Apps::RestartsController < ServerBaseController
+  def create
+    @app = App.find(params[:app_id])
+    RestartAppJob.perform_later(@app)
+  end
+end

--- a/app/controllers/env_vars_controller.rb
+++ b/app/controllers/env_vars_controller.rb
@@ -19,6 +19,6 @@ class EnvVarsController < ServerBaseController
   private
 
   def env_var_params
-    params.require(:env_var).permit(:key, :value)
+    params.require(:env_var).permit(:key, :value, :apply_immediately)
   end
 end

--- a/app/jobs/add_env_var_job.rb
+++ b/app/jobs/add_env_var_job.rb
@@ -2,7 +2,18 @@ class AddEnvVarJob < ApplicationJob
   queue_as :default
 
   def perform(app, env_var)
-    SshExecution.new(app.server).execute(command: "dokku config:set "\
-                                         "#{app.clean_name} '#{env_var.key}=#{env_var.value}'")
+    @apply_immediately = env_var.apply_immediately
+
+    SshExecution.new(app.server).
+      execute(command: "dokku config:set #{no_restart_argument}"\
+        "#{app.clean_name} '#{env_var.key}=#{env_var.value}'")
+  end
+
+  private
+
+  def no_restart_argument
+    return if @apply_immediately
+
+    "-no-restart "
   end
 end

--- a/app/jobs/restart_app_job.rb
+++ b/app/jobs/restart_app_job.rb
@@ -1,0 +1,8 @@
+class RestartAppJob < ApplicationJob
+  queue_as :default
+
+  def perform(app)
+    SshExecution.new(app.server).
+      execute(command: "dokku ps:restart #{app.clean_name}")
+  end
+end

--- a/app/models/env_var.rb
+++ b/app/models/env_var.rb
@@ -2,4 +2,6 @@ class EnvVar < ApplicationRecord
   belongs_to :app
 
   validates :key, presence: true, uniqueness: { scope: :app_id }
+
+  attr_accessor :apply_immediately
 end

--- a/app/views/apps/restarts/create.js.erb
+++ b/app/views/apps/restarts/create.js.erb
@@ -1,0 +1,1 @@
+alert("Your app is being restarted...")

--- a/app/views/env_vars/_form.html.erb
+++ b/app/views/env_vars/_form.html.erb
@@ -1,13 +1,27 @@
 <div class="box">
   <h3 class="title">Add new env var</h3>
   <%= form_for [@app.server, @app, @env_var], remote: true do |f| %>
+  <div class="field">
+    <%= f.label :key, class: "label" %>
     <div class="control">
-      <%= f.text_field :key, placeholder: "Key", hide_label: true, class: "input",
+      <%= f.text_field :key, placeholder: "Key", class: "input",
         data: { error: @env_var.errors[:key].first } %>
     </div>
+  </div>
+  <div class="field">
+    <%= f.label :value, class: "label" %>
     <div class="control">
-      <%= f.text_field :value, placeholder: "Value", hide_label: true, class: "input" %>
+      <%= f.text_field :value, placeholder: "Value", class: "input" %>
     </div>
+  </div>
+  <div class="field">
+    <div class="control">
+      <label class="checkbox">
+        <%= f.check_box :apply_immediately, checked: true %>
+        Immediately apply & restart app
+      </label>
+    </div>
+  </div>
     <%= f.submit "Add", class: "button is-primary" %>
   <% end %>
 </div>

--- a/app/views/env_vars/_form.html.erb
+++ b/app/views/env_vars/_form.html.erb
@@ -17,7 +17,7 @@
   <div class="field">
     <div class="control">
       <label class="checkbox">
-        <%= f.check_box :apply_immediately, checked: true %>
+        <%= f.check_box :apply_immediately, checked: false %>
         Immediately apply & restart app
       </label>
     </div>

--- a/app/views/env_vars/_form.html.erb
+++ b/app/views/env_vars/_form.html.erb
@@ -1,27 +1,21 @@
 <div class="box">
   <h3 class="title">Add new env var</h3>
   <%= form_for [@app.server, @app, @env_var], remote: true do |f| %>
-  <div class="field">
     <%= f.label :key, class: "label" %>
     <div class="control">
       <%= f.text_field :key, placeholder: "Key", class: "input",
         data: { error: @env_var.errors[:key].first } %>
     </div>
-  </div>
-  <div class="field">
     <%= f.label :value, class: "label" %>
     <div class="control">
       <%= f.text_field :value, placeholder: "Value", class: "input" %>
     </div>
-  </div>
-  <div class="field">
     <div class="control">
       <label class="checkbox">
         <%= f.check_box :apply_immediately, checked: false %>
         Immediately apply & restart app
       </label>
     </div>
-  </div>
-    <%= f.submit "Add", class: "button is-primary" %>
+  <%= f.submit "Add", class: "button is-primary" %>
   <% end %>
 </div>

--- a/app/views/env_vars/_restart_app.html.erb
+++ b/app/views/env_vars/_restart_app.html.erb
@@ -1,3 +1,3 @@
 <div class="box">
-  <%= button_to "Apply changes and restart app",  server_app_restarts_path(@app), remote: true, class: "button is-fullwidth is-light", data: { disable_with: "Restarting..." }  %>
+  <%= button_to "Apply changes and restart app",  server_app_restarts_path(@app.server, @app), remote: true, class: "button is-fullwidth is-light", data: { disable_with: "Restarting..." }  %>
 </div>

--- a/app/views/env_vars/_restart_app.html.erb
+++ b/app/views/env_vars/_restart_app.html.erb
@@ -1,0 +1,3 @@
+<div class="box">
+  <%= button_to "Apply changes and restart app",  server_app_restarts_path(@app), remote: true, class: "button is-fullwidth is-light", data: { disable_with: "Restarting..." }  %>
+</div>

--- a/app/views/env_vars/index.html.erb
+++ b/app/views/env_vars/index.html.erb
@@ -19,5 +19,7 @@
   </div>
   <div data-role="form" class="column is-4">
     <%= render "form" %>
+
+    <%= render "restart_app" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,9 @@ Rails.application.routes.draw do
     resource :health_check, only: [:create]
     resource :swap, only: [:show, :create, :destroy]
     resources :apps, only: [:index, :new, :create, :destroy, :show] do
+      scope module: :apps do
+        resources :restarts
+      end
       resources :services, controller: "app_services", only: :index do
         post :create, on: :member
         get :status, on: :member

--- a/test/controllers/apps/restarts_controller_test.rb
+++ b/test/controllers/apps/restarts_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class Apps::RestartsControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  test "POST create enqueues RestartAppJob" do
+    login_as users(:john)
+    app = apps(:example)
+
+    assert_enqueued_jobs 1, only: RestartAppJob do
+      post server_app_restarts_url(app.server, app), xhr: true
+    end
+  end
+end


### PR DESCRIPTION
This PR attempts to solve #247 by disabling the direct application of ENV vars by default. Instead a checkbox is presented where the user can enable applying an ENV var right away:

![schermafbeelding 2018-11-19 om 23 40 13](https://user-images.githubusercontent.com/42268/48739514-8524f580-ec54-11e8-97bb-01a94dc847e1.png)

As described in issue #247 - this would prevent Dokku from restarting the app multiple times if ENV vars are added shortly after each other. This results in dangling containers on the host because Dokku is not able to properly clean up old containers if multiple restarts run in parallel.

To allow for applying ENV var changes after they are added a widget is added to this page to restart the app. This way someone can make modifications to their ENV var setup (eg `dokku config <app>`) and then restart the app on a moment that it makes sense:

![schermafbeelding 2018-11-19 om 23 42 18](https://user-images.githubusercontent.com/42268/48739602-c87f6400-ec54-11e8-9d7d-524b77652b8d.png)
