### PR TITLE
Fix bug in passing apply_immediately setting to AddEnvVarJob

### DIFF
--- a/app/controllers/env_vars_controller.rb
+++ b/app/controllers/env_vars_controller.rb
@@ -7,7 +7,7 @@ class EnvVarsController < ServerBaseController
   def create
     @app = App.find_by!(id: params[:app_id], server: params[:server_id])
     @env_var = @app.env_vars.new(env_var_params)
-    AddEnvVarJob.perform_later(@app, @env_var) if @env_var.save
+    AddEnvVarJob.perform_later(@app, @env_var, @env_var.apply_immediately?) if @env_var.save
   end
 
   def destroy

--- a/app/jobs/add_env_var_job.rb
+++ b/app/jobs/add_env_var_job.rb
@@ -1,8 +1,8 @@
 class AddEnvVarJob < ApplicationJob
   queue_as :default
 
-  def perform(app, env_var)
-    @apply_immediately = env_var.apply_immediately
+  def perform(app, env_var, apply_immediately = false)
+    @apply_immediately = apply_immediately
 
     SshExecution.new(app.server).
       execute(command: "dokku config:set #{no_restart_argument}"\

--- a/app/models/env_var.rb
+++ b/app/models/env_var.rb
@@ -4,4 +4,8 @@ class EnvVar < ApplicationRecord
   validates :key, presence: true, uniqueness: { scope: :app_id }
 
   attr_accessor :apply_immediately
+
+  def apply_immediately?
+    self.apply_immediately == "1"
+  end
 end

--- a/app/models/env_var.rb
+++ b/app/models/env_var.rb
@@ -6,6 +6,6 @@ class EnvVar < ApplicationRecord
   attr_accessor :apply_immediately
 
   def apply_immediately?
-    self.apply_immediately == "1"
+    apply_immediately == "1"
   end
 end


### PR DESCRIPTION
Make sure to pass apply_immediately into the background job from the controller and don't rely on fetching the setting from the EnvVar model record in the background job.

This because the virtual attribute is not set anymore in the background job when fetching the model record.