### PR TITLE
Do not immediately restart when removing an env var

### DIFF
--- a/app/jobs/delete_env_var_job.rb
+++ b/app/jobs/delete_env_var_job.rb
@@ -3,6 +3,6 @@ class DeleteEnvVarJob < ApplicationJob
 
   def perform(app, env_var_name)
     SshExecution.new(app.server).
-      execute(command: "dokku config:unset #{app.clean_name} #{env_var_name}")
+      execute(command: "dokku config:unset -no-restart #{app.clean_name} #{env_var_name}")
   end
 end


### PR DESCRIPTION
This PR adds the `-no-restart` option to the Dokku command to remove an env var from an app. This to ensure that when removing multiple ENV vars shortly after each other, we don't get the race condition and dangling container problem as described in #254 and #247 