### PR TITLE
Execute SSL management commands via sudo

### DIFF
--- a/app/jobs/disable_ssl_job.rb
+++ b/app/jobs/disable_ssl_job.rb
@@ -1,5 +1,5 @@
 class DisableSSLJob < ApplicationJob
   def perform(app)
-    SshExecution.new(app.server).execute(command: "dokku certs:remove #{app.clean_name}")
+    SshExecution.new(app.server).execute(command: "sudo dokku certs:remove #{app.clean_name}")
   end
 end

--- a/app/jobs/enable_ssl_job.rb
+++ b/app/jobs/enable_ssl_job.rb
@@ -40,7 +40,7 @@ class EnableSSLJob < ApplicationJob
     SshExecution.new(app.server).
       execute(command: "tar -cvf #{server_tar_path} #{server_cert_path} #{server_key_path}")
     SshExecution.new(app.server).
-      execute(command: "dokku certs:add #{app.clean_name} < #{server_tar_path}")
+      execute(command: "sudo dokku certs:add #{app.clean_name} < #{server_tar_path}")
   end
 
   def clean_certificate_files

--- a/test/jobs/disable_ssl_job_test.rb
+++ b/test/jobs/disable_ssl_job_test.rb
@@ -4,7 +4,7 @@ class DisableSSLJobTest < ActiveJob::TestCase
   test "#perform should call out to SSHExecution" do
     app = apps(:ssl_enabled_app)
 
-    SshExecution.any_instance.expects(:execute).with(command: "dokku certs:remove #{app.clean_name}")
+    SshExecution.any_instance.expects(:execute).with(command: "sudo dokku certs:remove #{app.clean_name}")
     DisableSSLJob.perform_now(app)
   end
 end


### PR DESCRIPTION
This PR makes a small fix for #226 so that the SSL certificate adding and removal commands are executed via `sudo`. This fixes this feature for servers where a sudo account is used to manage Intercity and Dokku, instead of a full root account.

Fixes #226 