### PR TITLE
Add a CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,15 @@ jobs:
           - v1-dependencies-
 
       - run:
+          name: Install Chrome
+          command: |
+            sudo apt-get install -y libappindicator3-1
+            curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            sudo dpkg -i google-chrome.deb
+            sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
+            rm google-chrome.deb
+
+      - run:
           name: install dependencies
           command: |
             bundle install --jobs=4 --retry=3 --path vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,15 +66,9 @@ jobs:
       # run tests!
       - run:
           name: run tests
-          command: |
-            mkdir /tmp/test-results
-            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
-            
-            bundle exec rails test
+          command: bundle exec rails test
 
-      # collect reports
-      - store_test_results:
-          path: /tmp/test-results
       - store_artifacts:
-          path: /tmp/test-results
-          destination: test-results
+        path: tmp/screenshots
+      - store_artifacts:
+        path: log/test.log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
           POSTGRES_USER: circleci-app
           POSTGRES_DB: intercitynext_test
           POSTGRES_PASSWORD: ""
+      - image: circleci/redis
           
       
       # Specify service dependencies here if necessary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,7 @@ jobs:
     docker:
       # specify the version you desire here
        - image: circleci/ruby:2.4.1-node-browsers
-      
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-        - image: circleci/postgres:9.4
+       - image: circleci/postgres:9.4
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,6 @@ jobs:
           command: bundle exec rails test
 
       - store_artifacts:
-        path: tmp/screenshots
+          path: tmp/screenshots
       - store_artifacts:
-        path: log/test.log
+          path: log/test.log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,57 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+       - image: circleci/ruby:2.4.1-node-browsers
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+        - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+        
+      # Database setup
+      - run: bundle exec rake db:create
+      - run: bundle exec rake db:schema:load
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            mkdir /tmp/test-results
+            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
+            
+            bundle exec rails test
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,18 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-       - image: circleci/ruby:2.4.1-node-browsers
-       - image: circleci/postgres:9.4
+      - image: circleci/ruby:2.4.1-node-browsers
+      - image: circleci/postgres:9.4
+        environment:
+          POSTGRES_USER: circleci-app
+          POSTGRES_DB: intercitynext_test
+          POSTGRES_PASSWORD: ""
+          
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+       
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
           PGHOST: 127.0.0.1
           PGUSER: circleci-app
           RAILS_ENV: test
+          TESTOPTS: "--fail-fast"
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
           BUNDLE_PATH: vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,10 @@ jobs:
     docker:
       # specify the version you desire here
       - image: circleci/ruby:2.4.1-node-browsers
+        environment:
+          PGHOST: 127.0.0.1
+          PGUSER: circleci-app
+          RAILS_ENV: test
       - image: circleci/postgres:9.4
         environment:
           POSTGRES_USER: circleci-app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
           PGHOST: 127.0.0.1
           PGUSER: circleci-app
           RAILS_ENV: test
+          BUNDLE_JOBS: 3
+          BUNDLE_RETRY: 3
+          BUNDLE_PATH: vendor/bundle
       - image: circleci/postgres:9.4
         environment:
           POSTGRES_USER: circleci-app

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ group :test do
   gem "mocha"
   gem "shoulda"
   gem "timecop"
+  gem "minitest-fail-fast"
 end
 
 group :staging, :production do

--- a/Gemfile
+++ b/Gemfile
@@ -55,11 +55,11 @@ group :test do
   gem "codeclimate-test-reporter", require: nil
   gem "database_cleaner"
   gem "launchy"
+  gem "minitest-fail-fast"
   gem "minitest-reporters"
   gem "mocha"
   gem "shoulda"
   gem "timecop"
-  gem "minitest-fail-fast"
 end
 
 group :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,8 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
     minitest-reporters (1.1.19)
       ansi
       builder
@@ -356,6 +358,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   loofah (>= 2.2.3)
   meta_request
+  minitest-fail-fast
   minitest-reporters
   mocha
   net-ssh (= 3.0.1)


### PR DESCRIPTION
This PR adds a simple CirleCI config to `circleci/config.yml` so that we can start building intercity-next on CircleCI. CircleCI also offers a free public plan for public repositories on GitHub.

This sample file is taken from some other Firmhouse projects and uses a basic Postgres, Redis, Ruby, Rails setup.